### PR TITLE
feat: reuse session options in worker from master

### DIFF
--- a/lib/browser/browser.js
+++ b/lib/browser/browser.js
@@ -1,16 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const URI = require('urijs');
-const {URLSearchParams} = require('url');
 const history = require('./history');
-
-const DEFAULT_PORT = 4444;
-const OPTIONAL_SESSION_OPTS = [
-    'outputDir', 'agent', 'headers', 'transformRequest', 'transformResponse', 'strictSSL',
-    // cloud service opts
-    'user', 'key', 'region', 'headless'
-];
 
 module.exports = class Browser {
     static create(config, id, version) {
@@ -57,67 +48,6 @@ module.exports = class Browser {
 
     applyState(state) {
         _.extend(this._state, state);
-    }
-
-    _getSessionOpts({isAttach = false} = {}) {
-        const config = this._config;
-        const gridUri = new URI(config.gridUrl);
-        const capabilities = this.version
-            ? this._extendCapabilitiesByVersion()
-            : config.desiredCapabilities;
-        const connectionRetryTimeout = isAttach
-            ? config.httpTimeout
-            : config.sessionRequestTimeout || config.httpTimeout;
-
-        const options = {
-            protocol: gridUri.protocol(),
-            hostname: this._getGridHost(gridUri),
-            port: gridUri.port() ? parseInt(gridUri.port(), 10) : DEFAULT_PORT,
-            path: gridUri.path(),
-            queryParams: this._getQueryParams(gridUri.query()),
-            capabilities,
-            automationProtocol: config.automationProtocol,
-            logLevel: this._debug ? 'trace' : 'error',
-            connectionRetryTimeout,
-            connectionRetryCount: 0, // hermione has its own advanced retries
-            baseUrl: config.baseUrl,
-            waitforTimeout: config.waitTimeout,
-            waitforInterval: config.waitInterval
-        };
-
-        OPTIONAL_SESSION_OPTS.forEach((opt) => {
-            if (!_.isNull(config[opt])) {
-                options[opt] = config[opt];
-            }
-        });
-
-        return options;
-    }
-
-    _extendCapabilitiesByVersion() {
-        const {desiredCapabilities, sessionEnvFlags} = this._config;
-        const versionKeyName = desiredCapabilities.browserVersion || sessionEnvFlags.isW3C
-            ? 'browserVersion'
-            : 'version';
-
-        return _.assign({}, desiredCapabilities, {[versionKeyName]: this.version});
-    }
-
-    _getGridHost(url) {
-        return new URI({
-            username: url.username(),
-            password: url.password(),
-            hostname: url.hostname()
-        }).toString().slice(2); // URIjs leaves `//` prefix, removing it
-    }
-
-    _getQueryParams(query) {
-        if (_.isEmpty(query)) {
-            return {};
-        }
-
-        const urlParams = new URLSearchParams(query);
-        return Object.fromEntries(urlParams);
     }
 
     _addCommands() {

--- a/lib/browser/existing-browser.js
+++ b/lib/browser/existing-browser.js
@@ -25,8 +25,8 @@ module.exports = class ExistingBrowser extends Browser {
         this._meta = this._initMeta();
     }
 
-    async init({sessionId, sessionCaps} = {}, calibrator) {
-        this._session = await this._attachSession(sessionId, sessionCaps);
+    async init({sessionId, sessionCaps, sessionOpts} = {}, calibrator) {
+        this._session = await this._attachSession({sessionId, sessionCaps, sessionOpts});
 
         this._addHistory();
         this._addCommands();
@@ -121,8 +121,7 @@ module.exports = class ExistingBrowser extends Browser {
         }, params);
     }
 
-    _attachSession(sessionId, sessionCaps) {
-        const sessionOpts = this._getSessionOpts({isAttach: true});
+    _attachSession({sessionId, sessionCaps, sessionOpts = {}}) {
         const detectedSessionEnvFlags = sessionEnvironmentDetector({
             capabilities: sessionCaps,
             requestedCapabilities: sessionOpts.capabilities

--- a/lib/browser/new-browser.js
+++ b/lib/browser/new-browser.js
@@ -1,9 +1,19 @@
 'use strict';
 
+const {URLSearchParams} = require('url');
+const URI = require('urijs');
+const _ = require('lodash');
 const webdriverio = require('webdriverio');
 const Browser = require('./browser');
 const signalHandler = require('../signal-handler');
 const logger = require('../utils/logger');
+
+const DEFAULT_PORT = 4444;
+const OPTIONAL_SESSION_OPTS = [
+    'outputDir', 'agent', 'headers', 'transformRequest', 'transformResponse', 'strictSSL',
+    // cloud service opts
+    'user', 'key', 'region', 'headless'
+];
 
 module.exports = class NewBrowser extends Browser {
     constructor(config, id, version) {
@@ -58,5 +68,63 @@ module.exports = class NewBrowser extends Browser {
                 throw e;
             }
         }
+    }
+
+    _getSessionOpts() {
+        const config = this._config;
+        const gridUri = new URI(config.gridUrl);
+        const capabilities = this.version
+            ? this._extendCapabilitiesByVersion()
+            : config.desiredCapabilities;
+
+        const options = {
+            protocol: gridUri.protocol(),
+            hostname: this._getGridHost(gridUri),
+            port: gridUri.port() ? parseInt(gridUri.port(), 10) : DEFAULT_PORT,
+            path: gridUri.path(),
+            queryParams: this._getQueryParams(gridUri.query()),
+            capabilities,
+            automationProtocol: config.automationProtocol,
+            logLevel: this._debug ? 'trace' : 'error',
+            connectionRetryTimeout: config.sessionRequestTimeout || config.httpTimeout,
+            connectionRetryCount: 0, // hermione has its own advanced retries
+            baseUrl: config.baseUrl,
+            waitforTimeout: config.waitTimeout,
+            waitforInterval: config.waitInterval
+        };
+
+        OPTIONAL_SESSION_OPTS.forEach((opt) => {
+            if (!_.isNull(config[opt])) {
+                options[opt] = config[opt];
+            }
+        });
+
+        return options;
+    }
+
+    _extendCapabilitiesByVersion() {
+        const {desiredCapabilities, sessionEnvFlags} = this._config;
+        const versionKeyName = desiredCapabilities.browserVersion || sessionEnvFlags.isW3C
+            ? 'browserVersion'
+            : 'version';
+
+        return _.assign({}, desiredCapabilities, {[versionKeyName]: this.version});
+    }
+
+    _getGridHost(url) {
+        return new URI({
+            username: url.username(),
+            password: url.password(),
+            hostname: url.hostname()
+        }).toString().slice(2); // URIjs leaves `//` prefix, removing it
+    }
+
+    _getQueryParams(query) {
+        if (_.isEmpty(query)) {
+            return {};
+        }
+
+        const urlParams = new URLSearchParams(query);
+        return Object.fromEntries(urlParams);
     }
 };

--- a/lib/runner/test-runner/regular-test-runner.js
+++ b/lib/runner/test-runner/regular-test-runner.js
@@ -63,6 +63,7 @@ module.exports = class RegularTestRunner extends Runner {
                 browserVersion: this._browser.version,
                 sessionId: this._browser.sessionId,
                 sessionCaps: this._browser.capabilities,
+                sessionOpts: this._browser.publicAPI.options,
                 file: this._test.file
             }
         );

--- a/lib/worker/runner/browser-agent.js
+++ b/lib/worker/runner/browser-agent.js
@@ -12,12 +12,13 @@ module.exports = class BrowserAgent {
         this._pool = pool;
     }
 
-    getBrowser(sessionId, sessionCaps) {
+    getBrowser({sessionId, sessionCaps, sessionOpts}) {
         return this._pool.getBrowser({
             browserId: this.browserId,
             browserVersion: this.browserVersion,
             sessionId,
-            sessionCaps
+            sessionCaps,
+            sessionOpts
         });
     }
 

--- a/lib/worker/runner/browser-pool.js
+++ b/lib/worker/runner/browser-pool.js
@@ -18,7 +18,7 @@ module.exports = class BrowserPool {
         this._calibrator = new Calibrator();
     }
 
-    async getBrowser({browserId, browserVersion, sessionId, sessionCaps}) {
+    async getBrowser({browserId, browserVersion, sessionId, sessionCaps, sessionOpts}) {
         this._browsers[browserId] = this._browsers[browserId] || [];
 
         let browser = _.find(this._browsers[browserId], (browser) => {
@@ -33,7 +33,7 @@ module.exports = class BrowserPool {
             }
 
             browser = Browser.create(this._config, browserId, browserVersion, this._emitter);
-            await browser.init({sessionId, sessionCaps}, this._calibrator);
+            await browser.init({sessionId, sessionCaps, sessionOpts}, this._calibrator);
 
             this._browsers[browserId].push(browser);
 

--- a/lib/worker/runner/index.js
+++ b/lib/worker/runner/index.js
@@ -27,12 +27,12 @@ module.exports = class Runner extends AsyncEmitter {
         ]);
     }
 
-    runTest(fullTitle, {browserId, browserVersion, file, sessionId, sessionCaps}) {
+    runTest(fullTitle, {browserId, browserVersion, file, sessionId, sessionCaps, sessionOpts}) {
         const tests = this._testParser.parse({file, browserId});
         const test = tests.find((t) => t.fullTitle() === fullTitle);
         const browserAgent = BrowserAgent.create(browserId, browserVersion, this._browserPool);
         const runner = TestRunner.create(test, this._config.forBrowser(browserId), browserAgent);
 
-        return runner.run({sessionId, sessionCaps});
+        return runner.run({sessionId, sessionCaps, sessionOpts});
     }
 };

--- a/lib/worker/runner/test-runner/index.js
+++ b/lib/worker/runner/test-runner/index.js
@@ -23,14 +23,14 @@ module.exports = class TestRunner {
         this._browserAgent = browserAgent;
     }
 
-    async run({sessionId, sessionCaps}) {
+    async run({sessionId, sessionCaps, sessionOpts}) {
         const test = this._test;
         const hermioneCtx = test.hermioneCtx || {};
 
         let browser;
 
         try {
-            browser = await this._browserAgent.getBrowser(sessionId, sessionCaps);
+            browser = await this._browserAgent.getBrowser({sessionId, sessionCaps, sessionOpts});
         } catch (e) {
             throw Object.assign(e, {hermioneCtx});
         }

--- a/test/lib/browser/history/index.js
+++ b/test/lib/browser/history/index.js
@@ -149,7 +149,7 @@ describe('commands-history', () => {
                 sandbox.stub(webdriverio, 'attach').resolves(mkSessionStub_());
                 browser = mkExistingBrowser_({saveHistory: true});
 
-                await browser.init();
+                await browser.init({sessionOpts: {}});
             });
 
             mkTestsSet(() => browser, 'addCommand');

--- a/test/lib/runner/test-runner/regular-test-runner.js
+++ b/test/lib/runner/test-runner/regular-test-runner.js
@@ -54,7 +54,10 @@ describe('runner/test-runner/regular-test-runner', () => {
             sessionId: 'default-session-id',
             applyState: sinon.stub().callsFake(function(state) {
                 this.state = state;
-            })
+            }),
+            publicAPI: {
+                options: {default: 'options'}
+            }
         });
     };
 
@@ -78,7 +81,10 @@ describe('runner/test-runner/regular-test-runner', () => {
                 id: 'bro',
                 version: '1.0',
                 sessionId: '100500',
-                capabilities: {browserName: 'bro'}
+                capabilities: {browserName: 'bro'},
+                publicAPI: {
+                    options: {foo: 'bar'}
+                }
             }));
             const workers = mkWorkers_();
 
@@ -88,7 +94,8 @@ describe('runner/test-runner/regular-test-runner', () => {
                 browserId: 'bro',
                 browserVersion: '1.0',
                 sessionId: '100500',
-                sessionCaps: {browserName: 'bro'}
+                sessionCaps: {browserName: 'bro'},
+                sessionOpts: {foo: 'bar'}
             }));
         });
 

--- a/test/lib/worker/runner/browser-agent.js
+++ b/test/lib/worker/runner/browser-agent.js
@@ -14,13 +14,16 @@ describe('worker/browser-agent', () => {
                 browserId: 'bro-id',
                 browserVersion: null,
                 sessionId: '100-500',
-                sessionCaps: 'some-caps'
+                sessionCaps: 'some-caps',
+                sessionOpts: 'some-opts'
             }).returns({some: 'browser'});
+            const browserAgent = BrowserAgent.create('bro-id', null, browserPool);
 
-            assert.deepEqual(
-                BrowserAgent.create('bro-id', null, browserPool).getBrowser('100-500', 'some-caps'),
-                {some: 'browser'}
+            const browser = browserAgent.getBrowser(
+                {sessionId: '100-500', sessionCaps: 'some-caps', sessionOpts: 'some-opts'}
             );
+
+            assert.deepEqual(browser, {some: 'browser'});
         });
 
         it('should get a browser with specific version from the pool', () => {
@@ -28,13 +31,16 @@ describe('worker/browser-agent', () => {
                 browserId: 'bro-id',
                 browserVersion: '10.1',
                 sessionId: '100-500',
-                sessionCaps: 'some-caps'
+                sessionCaps: 'some-caps',
+                sessionOpts: 'some-opts'
             }).returns({some: 'browser'});
+            const browserAgent = BrowserAgent.create('bro-id', '10.1', browserPool);
 
-            assert.deepEqual(
-                BrowserAgent.create('bro-id', '10.1', browserPool).getBrowser('100-500', 'some-caps'),
-                {some: 'browser'}
+            const browser = browserAgent.getBrowser(
+                {sessionId: '100-500', sessionCaps: 'some-caps', sessionOpts: 'some-opts'}
             );
+
+            assert.deepEqual(browser, {some: 'browser'});
         });
     });
 

--- a/test/lib/worker/runner/browser-pool.js
+++ b/test/lib/worker/runner/browser-pool.js
@@ -99,12 +99,12 @@ describe('worker/browser-pool', () => {
             Browser.create.returns(browser);
 
             await createPool().getBrowser({
-                browserId: 'bro-id', sessionId: '100-500', sessionCaps: 'some-caps'
+                browserId: 'bro-id', sessionId: '100-500', sessionCaps: 'some-caps', sessionOpts: 'some-opts'
             });
 
             assert.calledOnceWith(
                 browser.init,
-                {sessionId: '100-500', sessionCaps: 'some-caps'},
+                {sessionId: '100-500', sessionCaps: 'some-caps', sessionOpts: 'some-opts'},
                 sinon.match.instanceOf(Calibrator)
             );
         });

--- a/test/lib/worker/runner/index.js
+++ b/test/lib/worker/runner/index.js
@@ -129,11 +129,11 @@ describe('worker/runner', () => {
             const test = makeTest({fullTitle: () => 'some test'});
             CachingTestParser.prototype.parse.returns([test]);
 
-            runner.runTest('some test', {sessionId: '100500', sessionCaps: 'some-caps'});
+            runner.runTest('some test', {sessionId: '100500', sessionCaps: 'some-caps', sessionOpts: 'some-opts'});
 
             assert.calledOnceWith(
                 TestRunner.prototype.run,
-                {sessionId: '100500', sessionCaps: 'some-caps'}
+                {sessionId: '100500', sessionCaps: 'some-caps', sessionOpts: 'some-opts'}
             );
         });
     });

--- a/test/lib/worker/runner/test-runner/index.js
+++ b/test/lib/worker/runner/test-runner/index.js
@@ -74,16 +74,18 @@ describe('worker/runner/test-runner', () => {
             const runner = opts.runner || mkRunner_({test});
             const sessionId = opts.sessionId || 'default-sessionId';
             const sessionCaps = opts.sessionCaps || 'default-session-caps';
+            const sessionOpts = opts.sessionOpts || 'default-session-opts';
 
-            return runner.run({sessionId, sessionCaps});
+            return runner.run({sessionId, sessionCaps, sessionOpts});
         };
 
         it('should request browser for passed session', async () => {
             const runner = mkRunner_();
+            const opts = {sessionId: '100500', sessionCaps: 'some-caps', sessionOpts: 'some-opts'};
 
-            await runner.run({sessionId: '100500', sessionCaps: 'some-caps'});
+            await runner.run(opts);
 
-            assert.calledOnceWithExactly(BrowserAgent.prototype.getBrowser, '100500', 'some-caps');
+            assert.calledOnceWithExactly(BrowserAgent.prototype.getBrowser, opts);
         });
 
         it('should create one time screenshooter', async () => {


### PR DESCRIPTION
I implement ability to share session options with worker in order to modify session endpoint only in master.
Moreover it is not make sense to recalculate session options twice if we can reuse it.