### PR TITLE
feat: add ability to use expect in component tests

### DIFF
--- a/src/runner/browser-env/vite/browser-modules/constants.ts
+++ b/src/runner/browser-env/vite/browser-modules/constants.ts
@@ -18,3 +18,7 @@ export const SOCKET_MAX_TIMEOUT = 2147483647;
 export const SOCKET_TIMED_OUT_ERROR = "operation has timed out";
 
 export const MAX_ARGS_LENGTH = 50;
+
+// used from - https://github.com/jestjs/jest/blob/726ca20752e38c18e20aa21740cec7aba7891946/packages/pretty-format/src/plugins/AsymmetricMatcher.ts#L11-L14
+export const ASYMMETRIC_MATCHER =
+    typeof Symbol === "function" && Symbol.for ? Symbol.for("jest.asymmetricMatcher") : 0x13_57_a5;

--- a/src/runner/browser-env/vite/browser-modules/driver.ts
+++ b/src/runner/browser-env/vite/browser-modules/driver.ts
@@ -17,6 +17,8 @@ import { BrowserEventNames } from "./types.js";
 type ProtocolCommandFn = (...args: unknown[]) => Promise<unknown>;
 type PropertiesObject = Record<string, PropertyDescriptor>;
 
+const SERVER_HANDLED_COMMANDS = ["debug", "saveScreenshot", "savePDF"];
+
 export default class ProxyDriver {
     static newSession(
         params: Record<string, unknown>,
@@ -65,10 +67,13 @@ function getAllProtocolCommands(): string[] {
 }
 
 function getMockedProtocolCommands(): PropertiesObject {
-    return [...getAllProtocolCommands(), ...window.__testplane__.customCommands].reduce((acc, commandName) => {
-        acc[commandName] = { value: mockCommand(commandName) };
-        return acc;
-    }, {} as PropertiesObject);
+    return [...getAllProtocolCommands(), ...SERVER_HANDLED_COMMANDS, ...window.__testplane__.customCommands].reduce(
+        (acc, commandName) => {
+            acc[commandName] = { value: mockCommand(commandName) };
+            return acc;
+        },
+        {} as PropertiesObject,
+    );
 }
 
 function mockCommand(commandName: string): ProtocolCommandFn {

--- a/src/runner/browser-env/vite/browser-modules/expect.ts
+++ b/src/runner/browser-env/vite/browser-modules/expect.ts
@@ -1,0 +1,96 @@
+import { expect, type Expect } from "expect";
+import { ASYMMETRIC_MATCHER } from "./constants.js";
+import { BrowserEventNames, type BrowserRunExpectMatcherPayload, MockMatcherFn } from "./types.js";
+
+export const initExpect = (): Expect => {
+    const mockedMatchers = mockMatchers(window.__testplane__.expectMatchers);
+    expect.extend(mockedMatchers);
+
+    return expect;
+};
+
+function mockMatchers(matcherNames: string[]): Record<string, MockMatcherFn> {
+    return matcherNames.reduce((acc, matcherName) => {
+        acc[matcherName] = mockMatcher(matcherName);
+        return acc;
+    }, {} as Record<string, MockMatcherFn>);
+}
+
+function mockMatcher(matcherName: string): MockMatcherFn {
+    const mockMatcherFn: MockMatcherFn = async function (context, ...args) {
+        if (
+            typeof args[0] === "object" &&
+            "$$typeof" in args[0] &&
+            args[0].$$typeof === ASYMMETRIC_MATCHER &&
+            args[0].asymmetricMatch
+        ) {
+            args[0] = {
+                $$typeof: args[0].toString(),
+                sample: args[0].sample,
+                inverse: args[0].inverse,
+            };
+        }
+
+        const matcherPayload: BrowserRunExpectMatcherPayload = {
+            name: matcherName,
+            scope: this,
+            args,
+        };
+
+        const isContextObject = typeof context === "object";
+
+        /**
+         * Check if context is a WebdriverIO.Element
+         */
+        if (isContextObject && "elementId" in context && typeof context.elementId === "string") {
+            matcherPayload.element = context;
+        }
+
+        /**
+         * Check if context is ChainablePromiseElement
+         */
+        if (isContextObject && "then" in context && typeof context.selector === "object") {
+            matcherPayload.element = await context;
+        }
+
+        /**
+         * Check if context is an `Element` and transform it into a WebdriverIO.Element
+         */
+        if (context instanceof Element) {
+            matcherPayload.element = await window.browser.$(context as unknown as HTMLElement);
+        } else if (isContextObject && !("sessionId" in context)) {
+            /**
+             * check if context is an object or promise and resolve it
+             * but not pass through the browser object
+             */
+            matcherPayload.context = context;
+            if ("then" in context) {
+                matcherPayload.context = await context;
+            }
+        } else if (!isContextObject) {
+            /**
+             * if context is not an object or promise, pass it through
+             */
+            matcherPayload.context = context;
+        }
+
+        /**
+         * Avoid serialization issues when sending over the element. If we create
+         * an element from an existing HTMLElement, it might have custom properties
+         * attached to it that can't be serialized.
+         */
+        if (matcherPayload.element && typeof matcherPayload.element.selector !== "string") {
+            matcherPayload.element.selector = "";
+        }
+
+        const { socket, config } = window.__testplane__;
+        // TODO: remove type casting after https://github.com/socketio/socket.io/issues/4925
+        const [{ pass, message }] = (await socket
+            .timeout(config.httpTimeout)
+            .emitWithAck(BrowserEventNames.runExpectMatcher, matcherPayload)) as [{ pass: boolean; message: string }];
+
+        return { pass, message: () => message };
+    };
+
+    return mockMatcherFn;
+}

--- a/src/runner/browser-env/vite/browser-modules/index.ts
+++ b/src/runner/browser-env/vite/browser-modules/index.ts
@@ -1,12 +1,14 @@
 import { remote } from "webdriverio";
 import { automationProtocolPath } from "virtual:@testplane/driver";
 import { MochaWrapper } from "./mocha/index.js";
+import { initExpect } from "./expect.js";
 
 window.__testplane__.browser = window.browser = await remote({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     automationProtocol: automationProtocolPath as any,
     capabilities: window.__testplane__.capabilities,
 });
+window.expect = initExpect();
 
 const mocha = MochaWrapper.create();
 await mocha.init();

--- a/src/runner/browser-env/vite/plugins/generate-index-html.ts
+++ b/src/runner/browser-env/vite/plugins/generate-index-html.ts
@@ -129,6 +129,16 @@ export const plugin = async (): Promise<Plugin[]> => {
                     return ["export default () => {};", "export const resolve = () => ''"].join("\n");
                 }
             },
+
+            transform(code, id): Rollup.TransformResult {
+                if (id.includes(".vite/deps/expect.js")) {
+                    return {
+                        code: code.replace("var fs = _interopRequireWildcard(require_graceful_fs());", "var fs = {};"),
+                    };
+                }
+
+                return { code };
+            },
         },
     ];
 };

--- a/src/runner/browser-env/vite/server.ts
+++ b/src/runner/browser-env/vite/server.ts
@@ -38,6 +38,7 @@ export class ViteServer {
             optimizeDeps: {
                 // listed deps are CJS packages and need to be compiled to ESM by Vite
                 include: [
+                    "expect",
                     // webdriverio deps
                     "aria-query",
                     "css-shorthand-properties",

--- a/src/runner/browser-env/vite/socket.ts
+++ b/src/runner/browser-env/vite/socket.ts
@@ -119,4 +119,20 @@ function handleBrowserEvents(
             cb([err as Error]);
         }
     });
+
+    socket.on(BrowserEventNames.runExpectMatcher, async (payload, cb) => {
+        const { runUuid } = socket.handshake.auth;
+
+        try {
+            const [response] = await io
+                .to(runUuid)
+                .except(socket.id)
+                .timeout(SOCKET_MAX_TIMEOUT)
+                .emitWithAck(BrowserEventNames.runExpectMatcher, payload);
+
+            cb(response);
+        } catch (err) {
+            cb([{ pass: false, message: (err as Error).message }]);
+        }
+    });
 }

--- a/src/runner/browser-env/vite/types.ts
+++ b/src/runner/browser-env/vite/types.ts
@@ -15,4 +15,5 @@ export interface ViteClientEvents extends BrowserViteEvents, ViteBrowserEvents {
 export enum BrowserEventNames {
     initialize = `${BROWSER_EVENT_PREFIX}:initialize`,
     runBrowserCommand = `${BROWSER_EVENT_PREFIX}:runBrowserCommand`,
+    runExpectMatcher = `${BROWSER_EVENT_PREFIX}:runExpectMatcher`,
 }

--- a/src/worker/browser-env/runner/test-runner/constants.ts
+++ b/src/worker/browser-env/runner/test-runner/constants.ts
@@ -1,1 +1,11 @@
 export const WORKER_EVENT_PREFIX = "worker";
+
+export const SUPPORTED_ASYMMETRIC_MATCHER = {
+    Any: "any",
+    Anything: "anything",
+    ArrayContaining: "arrayContaining",
+    ObjectContaining: "objectContaining",
+    StringContaining: "stringContaining",
+    StringMatching: "stringMatching",
+    CloseTo: "closeTo",
+} as const;

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -33,3 +33,9 @@ declare namespace globalThis {
     // eslint-disable-next-line no-var
     var expect: ExpectWebdriverIO.Expect;
 }
+
+// remove after updating expect-webdriverio@4 (should migrate to esm first)
+declare module "expect-webdriverio/lib/matchers" {
+    const matchers: ExpectWebdriverIO.Matchers<Promise<{ pass: boolean; message(): string }>, unknown>;
+    export default matchers;
+}


### PR DESCRIPTION
## What is done

Added the ability to use a `expect` instance on the client side when running component or unit tests.