### PR TITLE
fix: correctly connect to vite server from clients (worker, browser)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
     push:
-        branches: [master, component_testing]
+        branches: [master]
     pull_request:
-        branches: [master, component_testing]
+        branches: [master]
 
 jobs:
     build:

--- a/src/runner/browser-env/index.ts
+++ b/src/runner/browser-env/index.ts
@@ -2,6 +2,7 @@ import { ViteServer } from "./vite/server";
 import { MainRunner as NodejsEnvRunner } from "..";
 import { TestCollection } from "../../test-collection";
 import { Config } from "../../config";
+import RuntimeConfig from "../../config/runtime-config";
 import { Interceptor } from "../../events";
 import type { Stats as RunnerStats } from "../../stats";
 
@@ -17,6 +18,7 @@ export class MainRunner extends NodejsEnvRunner {
     async run(testCollection: TestCollection, stats: RunnerStats): Promise<void> {
         try {
             await this._viteServer.start();
+            RuntimeConfig.getInstance().extend({ viteBaseUrl: this._viteServer.baseUrl });
         } catch (err) {
             throw new Error(`Vite server failed to start: ${(err as Error).message}`);
         }

--- a/src/runner/browser-env/vite/browser-modules/globals.ts
+++ b/src/runner/browser-env/vite/browser-modules/globals.ts
@@ -9,7 +9,6 @@ const connectToSocket = (): BrowserViteSocket => {
             runUuid: window.__testplane__.runUuid,
             type: BROWSER_EVENT_PREFIX,
         },
-        transports: ["websocket"],
     }) as BrowserViteSocket;
 
     socket.on("connect_error", err => {

--- a/src/worker/browser-env/runner/test-runner/index.ts
+++ b/src/worker/browser-env/runner/test-runner/index.ts
@@ -9,6 +9,7 @@ import { wrapExecutionThread } from "./execution-thread";
 import { WorkerEventNames } from "./types";
 import { WORKER_EVENT_PREFIX, SUPPORTED_ASYMMETRIC_MATCHER } from "./constants";
 import logger from "../../../../utils/logger";
+import RuntimeConfig from "../../../../config/runtime-config";
 
 import { BrowserEventNames } from "../../../../runner/browser-env/vite/types";
 import type { Selector } from "webdriverio";
@@ -37,7 +38,7 @@ export class TestRunner extends NodejsEnvTestRunner {
     constructor(opts: WorkerTestRunnerCtorOpts) {
         super(opts);
 
-        this._socket = io(this._config.baseUrl, {
+        this._socket = io(RuntimeConfig.getInstance().viteBaseUrl, {
             transports: ["websocket"],
             auth: {
                 runUuid: this._runUuid,

--- a/test/src/worker/browser-env/runner/test-runner/index.ts
+++ b/test/src/worker/browser-env/runner/test-runner/index.ts
@@ -16,6 +16,7 @@ import BrowserAgent from "../../../../../../src/worker/runner/browser-agent";
 import history from "../../../../../../src/browser/history";
 import logger from "../../../../../../src/utils/logger";
 import OneTimeScreenshooter from "../../../../../../src/worker/runner/test-runner/one-time-screenshooter";
+import RuntimeConfig from "../../../../../../src/config/runtime-config";
 
 import ExpectWebdriverIO from "expect-webdriverio";
 import { BrowserEventNames } from "../../../../../../src/runner/browser-env/vite/types";
@@ -165,6 +166,8 @@ describe("worker/browser-env/runner/test-runner", () => {
         sandbox.stub(process, "pid").value(11111);
         sandbox.stub(logger, "warn");
 
+        sandbox.stub(RuntimeConfig, "getInstance").returns({ viteBaseUrl: "http://default" });
+
         socketClientStub = sandbox.stub().returns(mkSocket_());
         wrapExecutionThreadStub = sandbox.stub().callsFake(socket => wrapExecutionThread(socket));
 
@@ -175,13 +178,13 @@ describe("worker/browser-env/runner/test-runner", () => {
 
     describe("constructor", () => {
         describe("socket", () => {
-            it("should connect to the baseUrl", () => {
-                const baseUrl = "http://localhost:3333";
-                const config = makeBrowserConfigStub({ baseUrl }) as BrowserConfig;
+            it("should connect to the vite baseUrl from runtime config", () => {
+                const viteBaseUrl = "http://localhost:3333";
+                (RuntimeConfig.getInstance as SinonStub).returns({ viteBaseUrl });
 
-                mkRunner_({ config });
+                mkRunner_();
 
-                assert.calledOnceWith(socketClientStub, baseUrl);
+                assert.calledOnceWith(socketClientStub, viteBaseUrl);
             });
 
             it("should use websocket protocol when connecting", () => {


### PR DESCRIPTION
## What is done

If the user run browsers in the cloud, and the server is launched locally, then the user needs to launch some tunneler instance. In this case, the base url is usually substituted on tunneler url. Therefore, the worker must connect directly to the server (not use url from tunneler). And the browser should not explicitly specify the transport. Since the tunnel may not support a websocket connection.