### PR TITLE
feat: add ability to use dev server

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
     push:
-        branches: [master]
+        branches: [master, hermione]
     pull_request:
-        branches: [master]
+        branches: [master, hermione]
 
 jobs:
     build:

--- a/README.md
+++ b/README.md
@@ -1606,7 +1606,7 @@ The `browser` argument is a `WebdriverIO` session.
 Configuration data can be changed depending on extra conditions in the `prepareEnvironment` function.
 
 ### devServer
-Launch dev server on hermione init.
+Launch dev server on hermione initialize (INIT event).
 
 For example, this setup:
 ```js

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Hermione is a utility for integration testing of web pages using [WebdriverIO](h
     - [List of useful plugins](#list-of-useful-plugins)
   - [prepareBrowser](#preparebrowser)
   - [prepareEnvironment](#prepareenvironment)
+  - [devServer](#devserver)
 - [CLI](#cli)
   - [Reporters](#reporters)
   - [Require modules](#require-modules)
@@ -1603,6 +1604,40 @@ The `browser` argument is a `WebdriverIO` session.
 
 ### prepareEnvironment
 Configuration data can be changed depending on extra conditions in the `prepareEnvironment` function.
+
+### devServer
+Launch dev server on hermione init.
+
+For example, this setup:
+```js
+// .hermione.conf.js
+const SERVER_PORT = 3000;
+...
+module.exports = {
+    devServer: {
+        command: "npm run server:dev",
+        env: {PORT: SERVER_PORT},
+        readinessProbe: {
+            url: `http://localhost:${SERVER_PORT}/health`
+        }
+    }
+}
+```
+Will spawn child process "npm run server:dev", pass extra environment variable "PORT" with value "3000" and wait, until "http://localhost:3000/health" responds with 200-299 status code.
+
+Full list of parameters:
+ - command (optional) `String` – command to launch dev server. If null or not defined, dev server is disabled
+ - env (optional) `Record<string, string>` – extra environment variables to pass to child process, in addition to your `process.env` 
+ - args (optional)  `String[]` – arguments to pass to child process
+ - cwd (optional) `String` – current working directory of the child process. If not defined, hermione will try to find nearest "package.json", starting from the directory with hermione config
+ - logs (optional) `Boolean` – if enabled, shows dev server logs in the console with prefix "\[dev server\]". Enabled by default
+ - readinessProbe (optional) `Function | Object` - if function, ready check is completed when function is resolved. Receives child process object. Object by default
+   - url (optional) `String` – url to request ready check status. If not defined, ready check is disabled
+   - isReady (optional) `(fetchResponse => bool | Promise<bool>)` – predicate to check if server is ready based on `readinessProbe.url` fetch response. Returns `true` if statusCode is 2xx by default
+   - timeouts (optional) `Object` – server waiting timeouts
+     - waitServerTimeout (optional) `Number` - timeout to wait for server to be ready (ms). 60_000 by default
+     - probeRequestTimeout (optional) `Number` - one request timeout (ms), after which request will be aborted. 10_000 by default
+     - probeRequestInterval (optional) `Number` - interval between ready probe requests (ms). 1_000 by default
 
 ## CLI
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "@types/bluebird": "3.5.38",
         "@types/chai": "4.3.4",
         "@types/chai-as-promised": "7.1.5",
+        "@types/debug": "4.1.12",
         "@types/lodash": "4.14.191",
         "@types/node": "18.19.3",
         "@types/proxyquire": "1.3.28",
@@ -1461,6 +1462,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -1526,6 +1536,12 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
       "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q=="
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "18.19.3",
@@ -15832,6 +15848,15 @@
         "@types/node": "*"
       }
     },
+    "@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
@@ -15897,6 +15922,12 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.1.tgz",
       "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q=="
+    },
+    "@types/ms": {
+      "version": "0.7.34",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
+      "dev": true
     },
     "@types/node": {
       "version": "18.19.3",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@types/bluebird": "3.5.38",
     "@types/chai": "4.3.4",
     "@types/chai-as-promised": "7.1.5",
+    "@types/debug": "4.1.12",
     "@types/lodash": "4.14.191",
     "@types/node": "18.19.3",
     "@types/proxyquire": "1.3.28",

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -93,6 +93,22 @@ module.exports = {
     region: null,
     headless: null,
     isolation: null,
+    devServer: {
+        command: null,
+        cwd: null,
+        env: {},
+        args: [],
+        logs: true,
+        readinessProbe: {
+            url: null,
+            isReady: null,
+            timeouts: {
+                waitServerTimeout: 60000, // 60s
+                probeRequestTimeout: 10000, // 10s
+                probeRequestInterval: 1000, // 1s
+            },
+        },
+    },
 };
 
 module.exports.configPaths = [".hermione.conf.ts", ".hermione.conf.js"];

--- a/src/config/options.js
+++ b/src/config/options.js
@@ -116,11 +116,11 @@ const rootSection = section(
                     }
 
                     if (!_.isPlainObject(value)) {
-                        throw new Error("devServer.readinessProbe must be a function, object or null");
+                        throw new Error('"devServer.readinessProbe" must be a function, object or null');
                     }
 
                     if (!_.isUndefined(value.url) && typeof value.url !== "string" && value.url !== null) {
-                        throw new Error("devServer.readinessProbe.url must be a string or null");
+                        throw new Error('"devServer.readinessProbe.url" must be a string or null');
                     }
 
                     if (
@@ -128,17 +128,17 @@ const rootSection = section(
                         typeof value.isReady !== "function" &&
                         value.isReady !== null
                     ) {
-                        throw new Error("devServer.readinessProbe.isReady must be a function or null");
+                        throw new Error('"devServer.readinessProbe.isReady" must be a function or null');
                     }
 
                     if (!_.isUndefined(value.timeouts) && !_.isPlainObject(value.timeouts)) {
-                        throw new Error("devServer.readinessProbe.timeouts must be an object");
+                        throw new Error('"devServer.readinessProbe.timeouts" must be an object');
                     }
 
                     if (value.timeouts) {
                         ["waitServerTimeout", "probeRequestTimeout", "probeRequestInterval"].forEach(name => {
                             if (!_.isUndefined(value.timeouts[name]) && typeof value.timeouts[name] !== "number") {
-                                throw new Error(`devServer.readinessProbe.timeouts.${name} must be a number`);
+                                throw new Error(`"devServer.readinessProbe.timeouts.${name}" must be a number`);
                             }
                         });
                     }

--- a/src/config/options.js
+++ b/src/config/options.js
@@ -101,6 +101,61 @@ const rootSection = section(
                 "": { files: [] }, // Use `all` set with default values if sets were not specified in a config
             },
         ),
+
+        devServer: section({
+            command: options.optionalString("devServer.command"),
+            env: options.optionalObject("devServer.env"),
+            args: options.optionalArray("devServer.args"),
+            cwd: options.optionalString("devServer.cwd"),
+            logs: options.optionalBoolean("devServer.logs"),
+            readinessProbe: option({
+                defaultValue: defaults.devServer.readinessProbe,
+                validate: value => {
+                    if (typeof value === "function" || value === null) {
+                        return;
+                    }
+
+                    if (!_.isPlainObject(value)) {
+                        throw new Error("devServer.readinessProbe must be a function, object or null");
+                    }
+
+                    if (!_.isUndefined(value.url) && typeof value.url !== "string" && value.url !== null) {
+                        throw new Error("devServer.readinessProbe.url must be a string or null");
+                    }
+
+                    if (
+                        !_.isUndefined(value.isReady) &&
+                        typeof value.isReady !== "function" &&
+                        value.isReady !== null
+                    ) {
+                        throw new Error("devServer.readinessProbe.isReady must be a function or null");
+                    }
+
+                    if (!_.isUndefined(value.timeouts) && !_.isPlainObject(value.timeouts)) {
+                        throw new Error("devServer.readinessProbe.timeouts must be an object");
+                    }
+
+                    if (value.timeouts) {
+                        ["waitServerTimeout", "probeRequestTimeout", "probeRequestInterval"].forEach(name => {
+                            if (!_.isUndefined(value.timeouts[name]) && typeof value.timeouts[name] !== "number") {
+                                throw new Error(`devServer.readinessProbe.timeouts.${name} must be a number`);
+                            }
+                        });
+                    }
+                },
+                map: value =>
+                    typeof value === "function"
+                        ? value
+                        : {
+                              ...defaults.devServer.readinessProbe,
+                              ...(value || {}),
+                              timeouts: {
+                                  ...defaults.devServer.readinessProbe.timeouts,
+                                  ...((value && value.timeouts) || {}),
+                              },
+                          },
+            }),
+        }),
     }),
 );
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -1,6 +1,7 @@
 import type { SetRequired } from "type-fest";
 import type { BrowserConfig } from "./browser-config";
 import type { Test } from "../types";
+import type { ChildProcessWithoutNullStreams } from "child_process";
 
 export interface CompareOptsConfig {
     shouldCluster: boolean;
@@ -73,6 +74,22 @@ export interface SystemConfig {
     fileExtensions: Array<string>;
 }
 
+type ReadinessProbeIsReadyFn = (response: Awaited<ReturnType<typeof globalThis.fetch>>) => boolean | Promise<boolean>;
+
+type ReadinessProbeFn = (childProcess: ChildProcessWithoutNullStreams) => Promise<void>;
+
+type ReadinessProbeObj = {
+    url: string | null;
+    isReady: ReadinessProbeIsReadyFn | null;
+    timeouts: {
+        waitServerTimeout: number;
+        probeRequestTimeout: number;
+        probeRequestInterval: number;
+    };
+};
+
+type ReadinessProbe = ReadinessProbeFn | ReadinessProbeObj;
+
 export interface CommonConfig {
     configPath?: string;
     automationProtocol: "webdriver" | "devtools";
@@ -127,6 +144,15 @@ export interface CommonConfig {
         waitNetworkIdleTimeout: number;
         failOnNetworkError: boolean;
         ignoreNetworkErrorsPatterns: Array<RegExp | string>;
+    };
+
+    devServer: {
+        command: string | null;
+        cwd: string | null;
+        env: Record<string, string>;
+        args: Array<string>;
+        logs: boolean;
+        readinessProbe: ReadinessProbe;
     };
 }
 

--- a/src/dev-server/index.ts
+++ b/src/dev-server/index.ts
@@ -1,0 +1,53 @@
+import _ from "lodash";
+import { spawn } from "child_process";
+import { Config } from "../config";
+import { findCwd, pipeLogsWithPrefix, waitDevServerReady } from "./utils";
+import logger = require("../utils/logger");
+import type { Hermione } from "../hermione";
+
+export type DevServerOpts = { hermione: Hermione; devServerConfig: Config["devServer"]; configPath: string };
+
+export type InitDevServer = (opts: DevServerOpts) => Promise<void>;
+
+export const initDevServer: InitDevServer = async ({ hermione, devServerConfig, configPath }) => {
+    if (!devServerConfig || !devServerConfig.command) {
+        return;
+    }
+
+    logger.log("Starting dev server with command", `"${devServerConfig.command}"`);
+
+    if (!_.isEmpty(devServerConfig.args)) {
+        logger.log("Dev server args:", JSON.stringify(devServerConfig.args));
+    }
+
+    if (!_.isEmpty(devServerConfig.env)) {
+        logger.log("Dev server env:", JSON.stringify(devServerConfig.env, null, 4));
+    }
+
+    const devServer = spawn(devServerConfig.command, devServerConfig.args, {
+        env: { ...process.env, ...devServerConfig.env },
+        cwd: devServerConfig.cwd || findCwd(configPath),
+        shell: true,
+        windowsHide: true,
+    });
+
+    if (devServerConfig.logs) {
+        pipeLogsWithPrefix(devServer, "[dev server] ");
+    }
+
+    devServer.once("exit", (code, signal) => {
+        if (signal !== "SIGINT") {
+            const errorMessage = [
+                "An error occured while launching dev server",
+                `Dev server failed with code '${code}' (signal: ${signal})`,
+            ].join("\n");
+            hermione.halt(new Error(errorMessage), 5000);
+        }
+    });
+
+    process.once("exit", () => {
+        devServer.kill("SIGINT");
+    });
+
+    await waitDevServerReady(devServer, devServerConfig.readinessProbe);
+};

--- a/src/dev-server/index.ts
+++ b/src/dev-server/index.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import { spawn } from "child_process";
+import debug from "debug";
 import { Config } from "../config";
 import { findCwd, pipeLogsWithPrefix, waitDevServerReady } from "./utils";
 import logger = require("../utils/logger");
@@ -16,12 +17,14 @@ export const initDevServer: InitDevServer = async ({ hermione, devServerConfig, 
 
     logger.log("Starting dev server with command", `"${devServerConfig.command}"`);
 
+    const debugLog = debug("hermione:dev-server");
+
     if (!_.isEmpty(devServerConfig.args)) {
-        logger.log("Dev server args:", JSON.stringify(devServerConfig.args));
+        debugLog("Dev server args:", JSON.stringify(devServerConfig.args));
     }
 
     if (!_.isEmpty(devServerConfig.env)) {
-        logger.log("Dev server env:", JSON.stringify(devServerConfig.env, null, 4));
+        debugLog("Dev server env:", JSON.stringify(devServerConfig.env, null, 4));
     }
 
     const devServer = spawn(devServerConfig.command, devServerConfig.args, {

--- a/src/dev-server/utils.ts
+++ b/src/dev-server/utils.ts
@@ -1,0 +1,145 @@
+import { pipeline, Transform, TransformCallback } from "stream";
+import path from "path";
+import fs from "fs";
+import chalk from "chalk";
+import type { ChildProcessWithoutNullStreams } from "child_process";
+import logger from "../utils/logger";
+import type { Config } from "../config";
+
+export const findCwd = (configPath: string): string => {
+    let prev = configPath;
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        const dir = path.dirname(prev);
+
+        if (dir === prev) {
+            return path.dirname(configPath);
+        }
+
+        const foundPackageJson = fs.existsSync(path.join(dir, "package.json"));
+
+        if (foundPackageJson) {
+            return dir;
+        }
+
+        prev = dir;
+    }
+};
+
+class WithPrefixTransformer extends Transform {
+    prefix: string;
+    includePrefix: boolean;
+
+    constructor(prefix: string) {
+        super();
+
+        this.prefix = chalk.green(prefix);
+        this.includePrefix = true;
+    }
+
+    _transform(chunk: string, _: string, callback: TransformCallback): void {
+        const chunkString = chunk.toString();
+        const chunkRows = chunkString.split("\n");
+
+        const includeSuffix = chunkString.endsWith("\n") && chunkRows.pop() === "";
+
+        const resultPrefix = this.includePrefix ? this.prefix : "";
+        const resultSuffix = includeSuffix ? "\n" : "";
+        const resultData = resultPrefix + chunkRows.join("\n" + this.prefix) + resultSuffix;
+
+        this.push(resultData);
+        this.includePrefix = includeSuffix;
+
+        callback();
+    }
+}
+
+export const pipeLogsWithPrefix = (childProcess: ChildProcessWithoutNullStreams, prefix: string): void => {
+    const logOnErrorCb = (error: Error | null): void => {
+        if (error) {
+            logger.error("Got an error trying to pipeline dev server logs:", error.message);
+        }
+    };
+
+    pipeline(childProcess.stdout, new WithPrefixTransformer(prefix), process.stdout, logOnErrorCb);
+    pipeline(childProcess.stderr, new WithPrefixTransformer(prefix), process.stderr, logOnErrorCb);
+};
+
+const defaultIsReadyFn = (response: Awaited<ReturnType<typeof globalThis.fetch>>): boolean => {
+    return response.status >= 200 && response.status < 300;
+};
+
+export const waitDevServerReady = async (
+    devServer: ChildProcessWithoutNullStreams,
+    readinessProbe: Config["devServer"]["readinessProbe"],
+): Promise<void> => {
+    if (typeof readinessProbe !== "function" && !readinessProbe.url) {
+        return;
+    }
+
+    logger.log("Waiting for dev server to be ready");
+
+    if (typeof readinessProbe === "function") {
+        return Promise.resolve()
+            .then(() => readinessProbe(devServer))
+            .then(res => {
+                logger.log("Dev server is ready");
+
+                return res;
+            });
+    }
+
+    const isReadyFn = readinessProbe.isReady || defaultIsReadyFn;
+
+    let isSuccess = false;
+    let isError = false;
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+        setTimeout(() => {
+            if (!isError && !isSuccess) {
+                isError = true;
+                reject(new Error(`Dev server is still not ready after ${readinessProbe.timeouts.waitServerTimeout}ms`));
+            }
+        }, readinessProbe.timeouts.waitServerTimeout).unref();
+    });
+
+    const readyPromise = new Promise<void>(resolve => {
+        const tryToFetch = async (): Promise<void> => {
+            const signal = AbortSignal.timeout(readinessProbe.timeouts.probeRequestTimeout);
+
+            try {
+                const response = await fetch(readinessProbe.url!, { signal });
+                const isReady = await isReadyFn(response);
+
+                if (!isReady) {
+                    throw new Error("Dev server is not ready yet");
+                }
+
+                if (!isError && !isSuccess) {
+                    isSuccess = true;
+                    logger.log("Dev server is ready");
+                    resolve();
+                }
+            } catch (error) {
+                const err = error as { cause?: { code?: string } };
+
+                if (!isError && !isSuccess) {
+                    setTimeout(tryToFetch, readinessProbe.timeouts.probeRequestInterval).unref();
+
+                    const errorMessage = err && err.cause && (err.cause.code || err.cause);
+
+                    if (errorMessage && errorMessage !== "ECONNREFUSED") {
+                        logger.warn("Dev server ready probe failed:", errorMessage);
+                    }
+                }
+            }
+        };
+
+        tryToFetch();
+    });
+
+    return Promise.race([timeoutPromise, readyPromise]);
+};
+
+export default { findCwd, pipeLogsWithPrefix, waitDevServerReady };

--- a/src/hermione.ts
+++ b/src/hermione.ts
@@ -12,6 +12,7 @@ import { TestCollection } from "./test-collection";
 import { validateUnknownBrowsers } from "./validators";
 import { initReporters } from "./reporters";
 import logger from "./utils/logger";
+import { initDevServer } from "./dev-server";
 import { ConfigInput } from "./config/types";
 import { MasterEventHandler, Test } from "./types";
 
@@ -58,6 +59,16 @@ export class Hermione extends BaseHermione {
 
     extendCli(parser: CommanderStatic): void {
         this.emit(MasterEvents.CLI, parser);
+    }
+
+    protected async _init(): Promise<void> {
+        await initDevServer({
+            hermione: this,
+            devServerConfig: this._config.devServer,
+            configPath: this._config.configPath,
+        });
+
+        return super._init();
     }
 
     async run(

--- a/test/src/config/options.js
+++ b/test/src/config/options.js
@@ -660,4 +660,119 @@ describe("config options", () => {
             assert.deepEqual(config.sets, { "": { files: [], browsers: ["b1", "b2"], ignoreFiles: [] } });
         });
     });
+
+    describe("devServer.readinessProbe", () => {
+        const assertReadinessProbeThrows = (readinessProbe, errorMessage) => {
+            return assert.throws(() => {
+                parse_({
+                    options: {
+                        devServer: {
+                            readinessProbe,
+                        },
+                    },
+                });
+            }, errorMessage);
+        };
+
+        it("could be a function", () => {
+            const config = parse_({
+                options: {
+                    devServer: {
+                        readinessProbe: () => {},
+                    },
+                },
+            });
+
+            assert.isFunction(config.devServer.readinessProbe);
+        });
+
+        it("could be empty", () => {
+            const config = parse_({
+                options: {
+                    devServer: {
+                        readinessProbe: {},
+                    },
+                },
+            });
+
+            assert.deepEqual(config.devServer.readinessProbe, defaults.devServer.readinessProbe);
+        });
+
+        it("could have string url", () => {
+            const config = parse_({
+                options: {
+                    devServer: {
+                        readinessProbe: {
+                            url: "foo",
+                        },
+                    },
+                },
+            });
+
+            assert.deepEqual(config.devServer.readinessProbe.url, "foo");
+        });
+
+        it("could have custom isReady function", () => {
+            const config = parse_({
+                options: {
+                    devServer: {
+                        readinessProbe: {
+                            isReady: () => {},
+                        },
+                    },
+                },
+            });
+
+            assert.isFunction(config.devServer.readinessProbe.isReady);
+        });
+
+        it("could have overwritted timeouts", () => {
+            const config = parse_({
+                options: {
+                    devServer: {
+                        readinessProbe: {
+                            timeouts: {
+                                probeRequestTimeout: 100500,
+                            },
+                        },
+                    },
+                },
+            });
+
+            assert.equal(config.devServer.readinessProbe.timeouts.probeRequestTimeout, 100500);
+            assert.equal(
+                config.devServer.readinessProbe.timeouts.waitServerTimeout,
+                defaults.devServer.readinessProbe.timeouts.waitServerTimeout,
+            );
+            assert.equal(
+                config.devServer.readinessProbe.timeouts.probeRequestInterval,
+                defaults.devServer.readinessProbe.timeouts.probeRequestInterval,
+            );
+        });
+
+        it("should be a function or object", () => {
+            assertReadinessProbeThrows("foo", "devServer.readinessProbe must be a function, object or null");
+        });
+
+        it("url property should be a string", () => {
+            assertReadinessProbeThrows({ url: {} }, "devServer.readinessProbe.url must be a string or null");
+        });
+
+        it("isReady property should be a function", () => {
+            assertReadinessProbeThrows({ isReady: {} }, "devServer.readinessProbe.isReady must be a function or null");
+        });
+
+        it("timeouts property should be an object", () => {
+            assertReadinessProbeThrows({ timeouts: () => {} }, "devServer.readinessProbe.timeouts must be an object");
+        });
+
+        ["waitServerTimeout", "probeRequestTimeout", "probeRequestInterval"].forEach(timeoutName => {
+            it(`timeouts.${timeoutName} should be a number`, () => {
+                assertReadinessProbeThrows(
+                    { timeouts: { [timeoutName]: "foo" } },
+                    `devServer.readinessProbe.timeouts.${timeoutName} must be a number`,
+                );
+            });
+        });
+    });
 });

--- a/test/src/config/options.js
+++ b/test/src/config/options.js
@@ -751,26 +751,29 @@ describe("config options", () => {
         });
 
         it("should be a function or object", () => {
-            assertReadinessProbeThrows("foo", "devServer.readinessProbe must be a function, object or null");
+            assertReadinessProbeThrows("foo", '"devServer.readinessProbe" must be a function, object or null');
         });
 
         it("url property should be a string", () => {
-            assertReadinessProbeThrows({ url: {} }, "devServer.readinessProbe.url must be a string or null");
+            assertReadinessProbeThrows({ url: {} }, '"devServer.readinessProbe.url" must be a string or null');
         });
 
         it("isReady property should be a function", () => {
-            assertReadinessProbeThrows({ isReady: {} }, "devServer.readinessProbe.isReady must be a function or null");
+            assertReadinessProbeThrows(
+                { isReady: {} },
+                '"devServer.readinessProbe.isReady" must be a function or null',
+            );
         });
 
         it("timeouts property should be an object", () => {
-            assertReadinessProbeThrows({ timeouts: () => {} }, "devServer.readinessProbe.timeouts must be an object");
+            assertReadinessProbeThrows({ timeouts: () => {} }, '"devServer.readinessProbe.timeouts" must be an object');
         });
 
         ["waitServerTimeout", "probeRequestTimeout", "probeRequestInterval"].forEach(timeoutName => {
             it(`timeouts.${timeoutName} should be a number`, () => {
                 assertReadinessProbeThrows(
                     { timeouts: { [timeoutName]: "foo" } },
-                    `devServer.readinessProbe.timeouts.${timeoutName} must be a number`,
+                    `"devServer.readinessProbe.timeouts.${timeoutName}" must be a number`,
                 );
             });
         });

--- a/test/src/dev-server/index.ts
+++ b/test/src/dev-server/index.ts
@@ -22,6 +22,7 @@ describe("dev-server", () => {
     let pipeLogsWithPrefixStub: SinonStub;
     let waitDevServerReadyStub: SinonStub;
     let loggerStub: { log: SinonStub };
+    let debugLog: SinonStub;
     let hermioneStub: Hermione & { halt: SinonStub };
     let findCwdStub: SinonStub;
 
@@ -51,10 +52,12 @@ describe("dev-server", () => {
         findCwdStub = sandbox.stub();
 
         loggerStub = { log: sandbox.stub() };
+        debugLog = sandbox.stub();
 
         devServer = proxyquire("src/dev-server", {
             child_process: { spawn: spawnStub }, // eslint-disable-line camelcase
             "../utils/logger": loggerStub,
+            debug: sandbox.stub().withArgs("hermione:dev-server").returns(debugLog),
             "./utils": {
                 pipeLogsWithPrefix: pipeLogsWithPrefixStub,
                 waitDevServerReady: waitDevServerReadyStub,
@@ -154,7 +157,7 @@ describe("dev-server", () => {
                 args: ["-bar", "baz"],
             });
 
-            assert.calledWith(loggerStub.log, "Dev server args:", JSON.stringify(["-bar", "baz"]));
+            assert.calledWith(debugLog, "Dev server args:", JSON.stringify(["-bar", "baz"]));
         });
 
         it("should log dev server env, if specified", async () => {
@@ -163,7 +166,7 @@ describe("dev-server", () => {
                 env: { bar: "baz" },
             });
 
-            assert.calledWith(loggerStub.log, "Dev server env:", JSON.stringify({ bar: "baz" }, null, 4));
+            assert.calledWith(debugLog, "Dev server env:", JSON.stringify({ bar: "baz" }, null, 4));
         });
     });
 });

--- a/test/src/dev-server/index.ts
+++ b/test/src/dev-server/index.ts
@@ -1,0 +1,169 @@
+import _ from "lodash";
+import proxyquire from "proxyquire";
+import sinon, { type SinonStub } from "sinon";
+import type { PartialDeep } from "type-fest";
+import defaultConfig from "../../../src/config/defaults";
+import type { InitDevServer } from "../../../src/dev-server";
+import type { Config } from "../../../src/config";
+import type { Hermione } from "../../../src/hermione";
+import EventEmitter from "events";
+
+type DevServer = { initDevServer: InitDevServer };
+
+type DevServerConfig = Config["devServer"];
+type UserDevServerConfig = PartialDeep<DevServerConfig>;
+
+describe("dev-server", () => {
+    const sandbox = sinon.createSandbox();
+
+    let devServer: DevServer;
+    let spawnStub: SinonStub;
+    let childProcessStub: EventEmitter & { kill: SinonStub };
+    let pipeLogsWithPrefixStub: SinonStub;
+    let waitDevServerReadyStub: SinonStub;
+    let loggerStub: { log: SinonStub };
+    let hermioneStub: Hermione & { halt: SinonStub };
+    let findCwdStub: SinonStub;
+
+    const createDevServerConfig_ = (opts: UserDevServerConfig): Config["devServer"] => {
+        return _.defaultsDeep(opts, defaultConfig.devServer);
+    };
+
+    const initDevServer_ = (
+        devServerConfig: UserDevServerConfig = {},
+        configPath = "",
+        hermione = hermioneStub,
+    ): ReturnType<InitDevServer> => {
+        return devServer.initDevServer({
+            hermione,
+            configPath,
+            devServerConfig: createDevServerConfig_(devServerConfig),
+        });
+    };
+
+    beforeEach(() => {
+        childProcessStub = new EventEmitter() as EventEmitter & { kill: SinonStub };
+        childProcessStub.kill = sandbox.stub();
+
+        spawnStub = sandbox.stub().returns(childProcessStub);
+        pipeLogsWithPrefixStub = sandbox.stub();
+        waitDevServerReadyStub = sandbox.stub();
+        findCwdStub = sandbox.stub();
+
+        loggerStub = { log: sandbox.stub() };
+
+        devServer = proxyquire("src/dev-server", {
+            child_process: { spawn: spawnStub }, // eslint-disable-line camelcase
+            "../utils/logger": loggerStub,
+            "./utils": {
+                pipeLogsWithPrefix: pipeLogsWithPrefixStub,
+                waitDevServerReady: waitDevServerReadyStub,
+                findCwd: findCwdStub,
+            },
+        });
+
+        hermioneStub = {
+            halt: sandbox.stub(),
+        } as Hermione & { halt: SinonStub };
+    });
+
+    afterEach(() => sandbox.restore());
+
+    it("should not start child process if dev server command is not defined", async () => {
+        await initDevServer_();
+
+        assert.notCalled(spawnStub);
+    });
+
+    it("should start child process if dev server command is defined", async () => {
+        await initDevServer_({ command: "foo" });
+
+        assert.calledOnceWith(spawnStub, "foo");
+    });
+
+    it("should pass env, argv and cwd", async () => {
+        await initDevServer_({
+            command: "foo",
+            args: ["bar", "baz"],
+            env: { qux: "quux" },
+            cwd: "/quuux",
+        });
+
+        assert.calledOnceWith(spawnStub, "foo", ["bar", "baz"], {
+            env: { ...process.env, qux: "quux" },
+            cwd: "/quuux",
+            shell: true,
+            windowsHide: true,
+        });
+    });
+
+    it("should halt hermione on process kill", async () => {
+        await initDevServer_({
+            command: "foo",
+            logs: false,
+        });
+
+        childProcessStub.emit("exit", 9, "SIGKILL");
+
+        assert.calledOnce(hermioneStub.halt);
+    });
+
+    it("should kill dev server on process exit", async () => {
+        await initDevServer_({
+            command: "foo",
+            logs: false,
+        });
+
+        const processExitListeners = process.listeners("exit");
+        const devServerProcessExitListener = processExitListeners[processExitListeners.length - 1];
+
+        devServerProcessExitListener(9);
+
+        assert.calledOnceWith(childProcessStub.kill, "SIGINT");
+    });
+
+    describe("logs", () => {
+        it("should not pipe dev server logs if disabled", async () => {
+            await initDevServer_({
+                command: "foo",
+                logs: false,
+            });
+
+            assert.notCalled(pipeLogsWithPrefixStub);
+        });
+
+        it("should pipe dev server logs by default", async () => {
+            await initDevServer_({
+                command: "foo",
+            });
+
+            assert.calledOnceWith(pipeLogsWithPrefixStub, childProcessStub, "[dev server] ");
+        });
+
+        it("should log dev server start", async () => {
+            await initDevServer_({
+                command: "foo",
+            });
+
+            assert.calledWith(loggerStub.log, "Starting dev server with command", '"foo"');
+        });
+
+        it("should log dev server args, if specified", async () => {
+            await initDevServer_({
+                command: "foo",
+                args: ["-bar", "baz"],
+            });
+
+            assert.calledWith(loggerStub.log, "Dev server args:", JSON.stringify(["-bar", "baz"]));
+        });
+
+        it("should log dev server env, if specified", async () => {
+            await initDevServer_({
+                command: "foo",
+                env: { bar: "baz" },
+            });
+
+            assert.calledWith(loggerStub.log, "Dev server env:", JSON.stringify({ bar: "baz" }, null, 4));
+        });
+    });
+});

--- a/test/src/dev-server/utils.ts
+++ b/test/src/dev-server/utils.ts
@@ -1,0 +1,228 @@
+import _ from "lodash";
+import proxyquire from "proxyquire";
+import sinon, { type SinonSpy, type SinonStub } from "sinon";
+import type { ChildProcessWithoutNullStreams } from "child_process";
+import type { PartialDeep } from "type-fest";
+import { waitDevServerReady, findCwd } from "../../../src/dev-server/utils";
+import defaultConfig from "../../../src/config/defaults";
+import type { Config } from "../../../src/config";
+
+type WaitDevServerReady = typeof waitDevServerReady;
+type FindCwd = typeof findCwd;
+
+type ReadinessProbeConfig = Config["devServer"]["readinessProbe"];
+
+type UtilsModule = { waitDevServerReady: WaitDevServerReady; findCwd: FindCwd };
+
+describe("dev-server/utlls", () => {
+    const sandbox = sinon.createSandbox();
+
+    let utils: UtilsModule;
+    let fsExistsSyncStub: SinonStub;
+    let loggerStub: { log: SinonStub; warn: SinonStub };
+    let fetchStub = globalThis.fetch as SinonStub;
+    let setTimeoutSpy: SinonSpy;
+
+    beforeEach(() => {
+        fetchStub = sandbox.stub(globalThis, "fetch");
+        setTimeoutSpy = sandbox.spy(globalThis, "setTimeout");
+
+        fsExistsSyncStub = sandbox.stub().returns(false);
+
+        loggerStub = { log: sandbox.stub(), warn: sandbox.stub() };
+
+        utils = proxyquire("src/dev-server/utils", {
+            fs: { existsSync: fsExistsSyncStub },
+            "../utils/logger": loggerStub,
+        });
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe("findCwd", () => {
+        it("should return passed directory if near package.json exists", () => {
+            fsExistsSyncStub.withArgs("/foo/bar/package.json").returns(true);
+
+            const cwd = utils.findCwd("/foo/bar/.hermione.conf.js");
+
+            assert.equal(cwd, "/foo/bar");
+        });
+
+        it("should return parent directory which has package.json", () => {
+            fsExistsSyncStub.withArgs("/foo/bar/package.json").returns(true);
+
+            const cwd = utils.findCwd("/foo/bar/baz/qux/.hermione.conf.js");
+
+            assert.equal(cwd, "/foo/bar");
+        });
+
+        it("should fallback to config directory if package json is not found", () => {
+            const cwd = utils.findCwd("/foo/bar/baz/qux/.hermione.conf.js");
+
+            assert.equal(cwd, "/foo/bar/baz/qux");
+        });
+    });
+
+    describe("waitDevServerReady", () => {
+        const createReadinessProbe_ = (opts: PartialDeep<ReadinessProbeConfig> = {}): ReadinessProbeConfig => {
+            return _.defaultsDeep(opts, defaultConfig.devServer.readinessProbe);
+        };
+
+        const promiseDelay_ = <T>(timeout: number, response: T | void): Promise<T> =>
+            new Promise<T>(resolve => {
+                setTimeoutSpy(() => {
+                    resolve(response as T extends void ? never : T);
+                }, timeout);
+            });
+
+        it("should use readinessProbe function if defined", async () => {
+            const devServer = {} as ChildProcessWithoutNullStreams;
+            const readinessProbeResult = Promise.resolve({ foo: "bar" });
+            const readinessProbeFn = sandbox.stub().withArgs(devServer).returns(readinessProbeResult);
+
+            const result = (await utils.waitDevServerReady(devServer, readinessProbeFn)) as unknown;
+
+            assert.deepEqual(result, { foo: "bar" });
+        });
+
+        it("should return if readinessProbe section is undefined", async () => {
+            const devServer = {} as ChildProcessWithoutNullStreams;
+
+            await utils.waitDevServerReady(devServer, createReadinessProbe_());
+
+            assert.notCalled(loggerStub.log);
+            assert.notCalled(globalThis.fetch as SinonStub);
+        });
+
+        it("should fail on timeout", () => {
+            const devServer = {} as ChildProcessWithoutNullStreams;
+            fetchStub.withArgs("foo").returns(promiseDelay_(5));
+
+            const promise = utils.waitDevServerReady(
+                devServer,
+                createReadinessProbe_({
+                    url: "foo",
+                    timeouts: { waitServerTimeout: 5 },
+                }),
+            );
+
+            return assert.isRejected(promise, "Dev server is still not ready after 5ms");
+        });
+
+        it("should resolve on success", async () => {
+            const devServer = {} as ChildProcessWithoutNullStreams;
+            fetchStub.withArgs("foo").returns(promiseDelay_(5, { status: 200 }));
+
+            await utils.waitDevServerReady(devServer, createReadinessProbe_({ url: "foo" }));
+
+            assert.calledOnceWith(fetchStub, "foo");
+        });
+
+        it("should use custom isReady function", async () => {
+            const devServer = {} as ChildProcessWithoutNullStreams;
+            let retryCount = 0;
+            fetchStub.withArgs("foo").callsFake(() => promiseDelay_(5, { status: 200 + retryCount++ }));
+
+            await utils.waitDevServerReady(
+                devServer,
+                createReadinessProbe_({
+                    url: "foo",
+                    isReady: response => response.status === 201,
+                    timeouts: {
+                        probeRequestInterval: 2,
+                    },
+                }),
+            );
+
+            assert.calledTwice(fetchStub);
+        });
+
+        describe("logs", () => {
+            it("should log dev server is waiting", async () => {
+                const devServer = {} as ChildProcessWithoutNullStreams;
+                fetchStub.withArgs("foo").returns(promiseDelay_(5, { status: 200 }));
+
+                await utils.waitDevServerReady(devServer, createReadinessProbe_({ url: "foo" }));
+
+                assert.calledWith(loggerStub.log, "Waiting for dev server to be ready");
+            });
+
+            it("should log dev server is ready on resolve", async () => {
+                const devServer = {} as ChildProcessWithoutNullStreams;
+                fetchStub.withArgs("foo").returns(promiseDelay_(5, { status: 200 }));
+
+                await utils.waitDevServerReady(devServer, createReadinessProbe_({ url: "foo" }));
+
+                assert.calledWith(loggerStub.log, "Dev server is ready");
+            });
+
+            it("should not log dev server is ready on reject", async () => {
+                const devServer = {} as ChildProcessWithoutNullStreams;
+                fetchStub.withArgs("foo").returns(promiseDelay_(5));
+
+                await utils
+                    .waitDevServerReady(
+                        devServer,
+                        createReadinessProbe_({
+                            url: "foo",
+                            timeouts: { waitServerTimeout: 5 },
+                        }),
+                    )
+                    .catch(_.noop);
+
+                assert.calledWith(loggerStub.log, "Waiting for dev server to be ready");
+                assert.neverCalledWith(loggerStub.log, "Dev server is ready");
+            });
+
+            it("should not warn probe fail on ECONNRESET", async () => {
+                const devServer = {} as ChildProcessWithoutNullStreams;
+                fetchStub
+                    .withArgs("foo")
+                    .returns(new Promise((_, rej) => setTimeout(() => rej({ cause: { code: "ECONNREFUSED" } }), 1)));
+
+                await utils
+                    .waitDevServerReady(
+                        devServer,
+                        createReadinessProbe_({
+                            url: "foo",
+                            timeouts: {
+                                waitServerTimeout: 10,
+                                probeRequestInterval: 1,
+                            },
+                        }),
+                    )
+                    .catch(_.noop);
+
+                assert.neverCalledWith(loggerStub.warn, /Dev server ready probe failed/);
+            });
+
+            it("should not warn probe fail", async () => {
+                const devServer = {} as ChildProcessWithoutNullStreams;
+                fetchStub.withArgs("foo").returns(
+                    new Promise((_, rej) =>
+                        setTimeout(() => {
+                            rej({ cause: { code: "some error" } });
+                        }, 1),
+                    ),
+                );
+
+                await utils
+                    .waitDevServerReady(
+                        devServer,
+                        createReadinessProbe_({
+                            url: "foo",
+                            timeouts: {
+                                waitServerTimeout: 10,
+                                probeRequestInterval: 1,
+                            },
+                        }),
+                    )
+                    .catch(_.noop);
+
+                assert.calledWith(loggerStub.warn, "Dev server ready probe failed:", "some error");
+            });
+        });
+    });
+});


### PR DESCRIPTION
Added ability to specify dev server in config file:
Example
```js
const SERVER_PORT = 3000;
...
module.exports = {
    ...
    devServer: {
        command: "npm run server:dev",
        env: {PORT: SERVER_PORT},
        readinessProbe: {
            url: `http://localhost:${SERVER_PORT}/health`
        }
    }
}
```

Command could also be `node some/file.js` or something else