### PR TITLE
fix: types for describe, it

### DIFF
--- a/typings/api.d.ts
+++ b/typings/api.d.ts
@@ -1,6 +1,6 @@
-type TestDefinition = import("../src/test-reader/test-object/types").TestDefinition;
-type SuiteDefinition = import("../src/test-reader/test-object/types").SuiteDefinition;
-type TestHookDefinition = import("../src/test-reader/test-object/types").TestHookDefinition;
+type TestDefinition = import("../build/src/test-reader/test-object/types").TestDefinition;
+type SuiteDefinition = import("../build/src/test-reader/test-object/types").SuiteDefinition;
+type TestHookDefinition = import("../build/src/test-reader/test-object/types").TestHookDefinition;
 
 declare const it: TestDefinition;
 declare const describe: SuiteDefinition;


### PR DESCRIPTION
I made a mistake in this PR - https://github.com/gemini-testing/testplane/pull/933. Types should be imported from build folder, which is published in npm.

Fixes - https://github.com/gemini-testing/testplane/issues/940