### PR TITLE
fix(ct): do not fail on log html elements

### DIFF
--- a/src/runner/browser-env/vite/browser-modules/utils/console.ts
+++ b/src/runner/browser-env/vite/browser-modules/utils/console.ts
@@ -1,6 +1,8 @@
 import { CONSOLE_METHODS } from "../constants.js";
 import { BrowserEventNames } from "../types.js";
 
+const isDOMElement = (data: unknown): data is Element => data instanceof Element;
+
 export const wrapConsoleMethods = (): void => {
     const { socket } = window.__testplane__;
 
@@ -8,7 +10,9 @@ export const wrapConsoleMethods = (): void => {
         const origCommand = console[method].bind(console);
 
         console[method] = (...args: unknown[]): void => {
-            socket.emit(BrowserEventNames.callConsoleMethod, { method, args });
+            const preparedArgs = args.map(arg => (isDOMElement(arg) ? arg.outerHTML : arg));
+
+            socket.emit(BrowserEventNames.callConsoleMethod, { method, args: preparedArgs });
 
             origCommand(...args);
         };

--- a/src/runner/browser-env/vite/server.ts
+++ b/src/runner/browser-env/vite/server.ts
@@ -13,7 +13,7 @@ import { plugin as generateIndexHtml } from "./plugins/generate-index-html";
 import { Config } from "../../../config";
 import { VITE_DEFAULT_CONFIG_ENV } from "./constants";
 
-import type { ViteDevServer, InlineConfig } from "vite";
+import type { ViteDevServer, UserConfig, InlineConfig } from "vite";
 import type { BrowserTestRunEnvOptions } from "./types";
 
 export class ViteServer {
@@ -87,10 +87,10 @@ export class ViteServer {
         }
 
         const config = this._options.viteConfig;
-        let preparedConfig: InlineConfig;
+        let preparedConfig: UserConfig;
 
         if (_.isString(config)) {
-            preparedConfig = (await import(path.resolve(process.cwd(), config))).default as InlineConfig;
+            preparedConfig = (await import(path.resolve(process.cwd(), config))).default as UserConfig;
         } else if (_.isFunction(config)) {
             preparedConfig = await config(VITE_DEFAULT_CONFIG_ENV);
         } else {

--- a/src/runner/browser-env/vite/types.ts
+++ b/src/runner/browser-env/vite/types.ts
@@ -1,11 +1,11 @@
 import { BROWSER_EVENT_PREFIX } from "./constants";
-import type { InlineConfig, ConfigEnv } from "vite";
+import type { UserConfig, ConfigEnv } from "vite";
 import type { BrowserViteEvents, WorkerViteEvents, ViteBrowserEvents } from "./browser-modules/types";
 
 export type { BrowserViteEvents, WorkerViteEvents } from "./browser-modules/types";
 
 export interface BrowserTestRunEnvOptions {
-    viteConfig?: string | InlineConfig | ((env: ConfigEnv) => InlineConfig | Promise<InlineConfig>);
+    viteConfig?: string | UserConfig | ((env: ConfigEnv) => UserConfig | Promise<UserConfig>);
 }
 
 export interface ClientViteEvents extends BrowserViteEvents, WorkerViteEvents {}


### PR DESCRIPTION
## What is done

The problem occurs when you try to log an html element in test which use browser runner. Because html element has cyclic links and test crashes on call `JSON.stringify` when transferring such an element between processes.

So I use `outerHTML` if it exists.