### PR TITLE
fix: pass extra field on file events to fix breaking change

### DIFF
--- a/docs/migration-from-hermione.md
+++ b/docs/migration-from-hermione.md
@@ -21,6 +21,7 @@ Optional changes list. These are not required, but recommended:
 - Use `testplane_` environment variables instead of `hermione_` environment variables;
 - Use `TESTPLANE_` environment variables (for sets and skip browsers) instead of `HERMIONE_` environment variables;
 - Use explicit `hermione-` prefix for plugins, if necessary;
+- Use `testplane` field instead of `hermione` on event handlers;
 - Use [`TestplaneCtx`](./typescript.md#testplanectx-typings) instead of `HermioneCtx` type;
 - Use `executionContext.testplaneCtx` as browser property instead of `executionContext.hermioneCtx`;
 - If you use default [screenshotsDir](./config.md#screenshotsdir) value, rename "hermione/screens" directory to "testplane/screens" or specify the value "hermione/screens" explicitly;

--- a/src/test-reader/test-parser.js
+++ b/src/test-reader/test-parser.js
@@ -83,6 +83,7 @@ class TestParser extends EventEmitter {
                 this.emit(event, {
                     ...data,
                     testplane,
+                    hermione: testplane,
                     ...customOpts,
                 }),
             );


### PR DESCRIPTION
Typings are already correct: https://github.com/gemini-testing/testplane/blob/1e797a6d257a85ef1954a256879ba8703e24a7f0/src/types/index.ts#L163-L168