### PR TITLE
feat: add traceparent header to all requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The documentation is divided into several sections:
 - [Testplane Events](docs/events.md)
 - [Testplane Programmatic API](docs/programmatic-api.md)
 - [Testplane Component Testing (experimental)](docs/component-testing.md)
+- [Testplane Debugging](docs/debugging.md)
 
 ## Rename from "Hermione"
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,9 @@
+<!-- DOCTOC SKIP -->
+## Debugging
+
+### Tracing
+
+Testpalne supports [OpenTelemetry](https://opentelemetry.io) standard for tracing. A randomly generated `traceparent` header is added to all requests. It is generated according to [w3c](https://www.w3.org/TR/trace-context/#traceparent-header) specification.
+
+You can use `traceparent` to trace the execution of individual tests.
+

--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -95,6 +95,9 @@ module.exports = class Browser {
                             this.state.testXReqId
                         }${X_REQUEST_ID_DELIMITER}${crypto.randomUUID()}`;
                     }
+                    if (!req.headers["traceparent"] && this.state.traceparent) {
+                        req.headers["traceparent"] = this.state.traceparent;
+                    }
 
                     return req;
                 };

--- a/src/browser/existing-browser.js
+++ b/src/browser/existing-browser.js
@@ -175,6 +175,7 @@ module.exports = class ExistingBrowser extends Browser {
             pid: process.pid,
             browserVersion: this.version,
             testXReqId: this.state.testXReqId,
+            traceparent: this.state.traceparent,
             ...this._config.meta,
         };
     }

--- a/src/runner/test-runner/regular-test-runner.js
+++ b/src/runner/test-runner/regular-test-runner.js
@@ -81,14 +81,29 @@ module.exports = class RegularTestRunner extends Runner {
         this._test.duration = Date.now() - this._test.startTime;
     }
 
+    _getTraceparent() {
+        const version = "00";
+        const traceId = crypto.randomBytes(16).toString("hex");
+        const parentId = "00" + crypto.randomBytes(7).toString("hex");
+        const traceFlag = "01";
+
+        return `${version}-${traceId}-${parentId}-${traceFlag}`;
+    }
+
     async _getBrowser() {
         try {
-            const state = { testXReqId: crypto.randomUUID() };
+            const state = {
+                testXReqId: crypto.randomUUID(),
+                traceparent: this._getTraceparent(),
+            };
 
             this._browser = await this._browserAgent.getBrowser({ state });
 
             // TODO: move logic to caching pool (in order to use correct state for cached browsers)
-            if (this._browser.state.testXReqId !== state.testXReqId) {
+            if (
+                this._browser.state.testXReqId !== state.testXReqId ||
+                this._browser.state.traceparent !== state.traceparent
+            ) {
                 this._browser.applyState(state);
             }
 


### PR DESCRIPTION
A randomly generated traceparent header unique for each test is added to all requests.