### PR TITLE
feat: export TestFunctionCtx type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export type {
     HermioneCtx,
     GlobalHelper,
     TestplaneCtx,
+    TestFunctionCtx,
 } from "./types";
 export type { Config } from "./config";
 export type { ConfigInput } from "./config/types";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ export type { Browser as WdioBrowser } from "webdriverio";
 
 export type { Test } from "../test-reader/test-object/test";
 export type { Suite } from "../test-reader/test-object/suite";
+export type { TestFunctionCtx } from "../test-reader/test-object/types";
 
 export type { AssertViewOpts } from "../browser/commands/types";
 


### PR DESCRIPTION
After this PR, user would be able to use clean module augmentation. Example:
```ts
import type { TestFunctionCtx as TestplaneTestFunctionCtx } from "testplane";

declare module 'testplane' {
    export interface TestFunctionCtx extends TestplaneTestFunctionCtx {
        myFunc(var1: string, var2: number): Promise<void>;
    }
}
```

Also he would be able to pass test function context to other functions and type them properly:
https://github.com/gemini-testing/testplane/discussions/939