### PR TITLE
feat: implement ability to specify browser as passive

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -56,6 +56,7 @@
   - [region](#region)
   - [headless](#headless)
   - [isolation](#isolation)
+  - [passive](#passive)
 - [system](#system)
   - [debug](#debug)
   - [mochaOpts](#mochaopts)
@@ -197,6 +198,7 @@ Option name               | Description
 `region`                  | Ability to choose different datacenters for run in cloud service. Default value is `null`.
 `headless`                | Ability to run headless browser in cloud service. Default value is `null`.
 `isolation`               | Ability to execute tests in isolated clean-state environment ([incognito browser context](https://chromedevtools.github.io/devtools-protocol/tot/Target/#method-createBrowserContext)). Default value is `false`, but `true` for chrome@93 and higher.
+`passive`                 | Ability to make browser passive. Tests are not run in passive browsers by default. Default value is `false`.
 
 #### desiredCapabilities
 **Required.** Used WebDriver [DesiredCapabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities). For example,
@@ -490,6 +492,11 @@ Ability to run headless browser in cloud service. Default value is `null`. Can b
 
 ####  isolation
 Ability to execute tests in isolated clean-state environment ([incognito browser context](https://chromedevtools.github.io/devtools-protocol/tot/Target/#method-createBrowserContext)). It means that `testsPerSession` can be set to `Infinity` in order to speed up tests execution and save browser resources. Currently works only in chrome@93 and higher. Default value is `null`, but `true` for chrome@93 and higher.
+
+#### passive
+Ability to make browser passive. Tests are not run in passive browsers by default. Using [testplane.also.in](./writing-tests.md#also) makes it possible to run test or suite before which it is specified.
+
+:warning: When using this option, you need to get rid of the [hermione-passive-browsers](https://github.com/gemini-testing/testplane-passive-browsers) plugin, since they work together incorrectly.
 
 ### system
 

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -174,6 +174,27 @@ it('should work another way', function() {
 ```
 The test will be processed in all browsers and **silently** skipped in `ie9`.
 
+### Also
+This feature allows you to run the specified suite or test in [passive browser](./config.md#passive).
+You can do this by using the global `testplane.also` helper. It supports the following methods:
+
+- `.in` – Adds matchers for browsers.
+
+These methods take the following arguments:
+
+- browser {String|RegExp|Array<String|RegExp>} — A matcher for browser(s) to enable test.
+
+For example:
+```js
+// ...
+testplane.also.in('yabro');
+
+it('should run in passive browser', function() {
+    return doSomething();
+});
+```
+The test will be run in passive browser "yabro" and in all other not passive browsers.
+
 ### Config overriding
 You can override some config settings for specific test, suite or hook via `testplane.config.*` notation.
 

--- a/src/config/browser-options.js
+++ b/src/config/browser-options.js
@@ -362,5 +362,7 @@ function buildBrowserOptions(defaultFactory, extra) {
                 return caps ? isSupportIsolation(caps.browserName, caps.browserVersion) : value;
             },
         }),
+
+        passive: options.boolean("passive"),
     });
 }

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -110,6 +110,7 @@ module.exports = {
             },
         },
     },
+    passive: false,
 };
 
 module.exports.configPaths = [".testplane.conf.ts", ".testplane.conf.js", ".hermione.conf.ts", ".hermione.conf.js"];

--- a/src/test-reader/build-instructions.js
+++ b/src/test-reader/build-instructions.js
@@ -63,6 +63,18 @@ function extendWithTimeout({ treeBuilder, config }) {
     });
 }
 
+function disableInPassiveBrowser({ treeBuilder, config }) {
+    const { passive } = config;
+
+    if (!passive) {
+        return;
+    }
+
+    treeBuilder.addTrap(testObject => {
+        testObject.disable();
+    });
+}
+
 function buildGlobalSkipInstruction(config) {
     const { value: skipBrowsers, key: envKey } = env.parseCommaSeparatedValue([
         "TESTPLANE_SKIP_BROWSERS",
@@ -88,6 +100,7 @@ module.exports = {
         extendWithBrowserId,
         extendWithBrowserVersion,
         extendWithTimeout,
+        disableInPassiveBrowser,
         buildGlobalSkipInstruction,
     },
 };

--- a/src/test-reader/controllers/also-controller.ts
+++ b/src/test-reader/controllers/also-controller.ts
@@ -1,0 +1,41 @@
+import { EventEmitter } from "events";
+import { TestReaderEvents as ReadEvents } from "../../events";
+import type { Test } from "../../types";
+
+interface TreeBuilder {
+    addTrap: (trap: (test: Test) => void) => void;
+}
+
+export class AlsoController {
+    #eventBus: EventEmitter;
+
+    static create<T extends AlsoController>(this: new (eventBus: EventEmitter) => T, eventBus: EventEmitter): T {
+        return new this(eventBus);
+    }
+
+    constructor(eventBus: EventEmitter) {
+        this.#eventBus = eventBus;
+    }
+
+    in(matchers: string | RegExp | Array<string | RegExp>): this {
+        this.#addTrap(browserId => this.#match(browserId, matchers));
+
+        return this;
+    }
+
+    #addTrap(match: (browserId: string) => boolean): void {
+        this.#eventBus.emit(ReadEvents.NEW_BUILD_INSTRUCTION, ({ treeBuilder }: { treeBuilder: TreeBuilder }) => {
+            treeBuilder.addTrap(obj => {
+                if (match(obj.browserId)) {
+                    obj.enable();
+                }
+            });
+        });
+    }
+
+    #match(browserId: string, matchers: string | RegExp | Array<string | RegExp>): boolean {
+        return ([] as Array<string | RegExp>).concat(matchers).some(m => {
+            return m instanceof RegExp ? m.test(browserId) : m === browserId;
+        });
+    }
+}

--- a/src/test-reader/test-object/configurable-test-object.ts
+++ b/src/test-reader/test-object/configurable-test-object.ts
@@ -33,6 +33,11 @@ export class ConfigurableTestObject extends TestObject {
         this.silentSkip = true;
     }
 
+    enable(): void {
+        this.disabled = false;
+        this.silentSkip = false;
+    }
+
     get id(): ConfigurableTestObjectData["id"] {
         return this.#data.id;
     }

--- a/src/test-reader/test-object/configurable-test-object.ts
+++ b/src/test-reader/test-object/configurable-test-object.ts
@@ -86,7 +86,7 @@ export class ConfigurableTestObject extends TestObject {
     }
 
     get browserId(): ConfigurableTestObjectData["browserId"] {
-        return this.#getInheritedProperty<ConfigurableTestObjectData["browserId"]>("browserId", undefined);
+        return this.#getInheritedProperty<ConfigurableTestObjectData["browserId"]>("browserId", "");
     }
 
     set browserVersion(version: string) {

--- a/src/test-reader/test-object/hook.ts
+++ b/src/test-reader/test-object/hook.ts
@@ -34,6 +34,6 @@ export class Hook extends TestObject {
     }
 
     get browserId(): ConfigurableTestObjectData["browserId"] {
-        return this.parent ? this.parent.browserId : undefined;
+        return this.parent ? this.parent.browserId : "";
     }
 }

--- a/src/test-reader/test-object/types.ts
+++ b/src/test-reader/test-object/types.ts
@@ -14,7 +14,7 @@ export type ConfigurableTestObjectData = {
     disabled: boolean;
     skipReason: string;
     silentSkip: boolean;
-    browserId?: string;
+    browserId: string;
     browserVersion?: string;
 };
 

--- a/src/test-reader/test-parser.js
+++ b/src/test-reader/test-parser.js
@@ -2,6 +2,7 @@ const { EventEmitter } = require("events");
 const { InstructionsList, Instructions } = require("./build-instructions");
 const { SkipController } = require("./controllers/skip-controller");
 const { OnlyController } = require("./controllers/only-controller");
+const { AlsoController } = require("./controllers/also-controller");
 const { ConfigController } = require("./controllers/config-controller");
 const browserVersionController = require("./controllers/browser-version-controller");
 const { TreeBuilder } = require("./tree-builder");
@@ -41,6 +42,7 @@ class TestParser extends EventEmitter {
             ctx: _.clone(ctx),
             only: OnlyController.create(eventBus),
             skip: SkipController.create(eventBus),
+            also: AlsoController.create(eventBus),
         };
 
         global.testplane = toolGlobals;

--- a/src/test-reader/test-parser.js
+++ b/src/test-reader/test-parser.js
@@ -50,6 +50,7 @@ class TestParser extends EventEmitter {
             .push(Instructions.extendWithBrowserId)
             .push(Instructions.extendWithBrowserVersion)
             .push(Instructions.extendWithTimeout)
+            .push(Instructions.disableInPassiveBrowser)
             .push(Instructions.buildGlobalSkipInstruction(config));
 
         this.#applyInstructionsEvents(eventBus);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ import { StatsResult } from "../stats";
 import { ConfigController } from "../test-reader/controllers/config-controller";
 import { OnlyController } from "../test-reader/controllers/only-controller";
 import { SkipController } from "../test-reader/controllers/skip-controller";
+import { AlsoController } from "../test-reader/controllers/also-controller";
 import { BrowserVersionController } from "../test-reader/controllers/browser-version-controller";
 import { WorkerProcess } from "../utils/worker-process";
 import { BaseTestplane } from "../base-testplane";
@@ -161,6 +162,7 @@ export interface GlobalHelper {
     ctx: TestplaneCtx;
     skip: SkipController;
     only: OnlyController;
+    also: AlsoController;
     browser: (browserName: string) => BrowserVersionController;
     config: ConfigController;
 }

--- a/test/src/config/browser-options.js
+++ b/test/src/config/browser-options.js
@@ -1221,9 +1221,15 @@ describe("config browser-options", () => {
         });
     }
 
-    ["calibrate", "compositeImage", "resetCursor", "strictTestsOrder", "waitOrientationChange", "isolation"].forEach(
-        option => describe(option, () => testBooleanOption(option)),
-    );
+    [
+        "calibrate",
+        "compositeImage",
+        "resetCursor",
+        "strictTestsOrder",
+        "waitOrientationChange",
+        "isolation",
+        "passive",
+    ].forEach(option => describe(option, () => testBooleanOption(option)));
 
     describe("isolation", () => {
         it("should set to 'true' if browser support isolation", () => {

--- a/test/src/test-reader/build-instructions.js
+++ b/test/src/test-reader/build-instructions.js
@@ -216,6 +216,39 @@ describe("test-reader/build-instructions", () => {
             });
         });
 
+        describe("disableInPassiveBrowser", () => {
+            describe("should not add decorator to tree builder if", () => {
+                it("'passive' option is not specified in config", () => {
+                    execTrapInstruction_(Instructions.extendWithTimeout, { config: {} });
+
+                    assert.notCalled(TreeBuilder.prototype.addTrap);
+                });
+
+                it("'passive' option set to 'false' in config", () => {
+                    execTrapInstruction_(Instructions.extendWithTimeout, {
+                        config: {
+                            passive: false,
+                        },
+                    });
+
+                    assert.notCalled(TreeBuilder.prototype.addTrap);
+                });
+            });
+
+            it("should disable passed test object if 'passive' option is set to 'true' in config", () => {
+                const decorator = execTrapInstruction_(Instructions.disableInPassiveBrowser, {
+                    config: {
+                        passive: true,
+                    },
+                });
+                const testObject = { disable: sandbox.stub() };
+
+                decorator(testObject);
+
+                assert.calledOnce(testObject.disable);
+            });
+        });
+
         describe("buildGlobalSkipInstruction", () => {
             beforeEach(() => {
                 sandbox.stub(validators, "validateUnknownBrowsers");

--- a/test/src/test-reader/controllers/also-controller.ts
+++ b/test/src/test-reader/controllers/also-controller.ts
@@ -1,0 +1,107 @@
+import { EventEmitter } from "node:events";
+import sinon, { SinonStub } from "sinon";
+import { AlsoController } from "../../../../src/test-reader/controllers/also-controller";
+import { TreeBuilder } from "../../../../src/test-reader/tree-builder";
+import { ConfigurableTestObject } from "../../../../src/test-reader/test-object/configurable-test-object";
+import { TestReaderEvents as ReadEvents } from "../../../../src/events";
+
+describe("test-reader/controllers/also-controller", () => {
+    const sandbox = sinon.createSandbox();
+
+    const mkController_ = (): AlsoController => {
+        const eventBus = new EventEmitter().on(ReadEvents.NEW_BUILD_INSTRUCTION, instruction =>
+            instruction({ treeBuilder: new TreeBuilder() }),
+        );
+
+        return AlsoController.create(eventBus);
+    };
+
+    const mkTestObject_ = (
+        { browserId }: { browserId: string } = { browserId: "default-browser-id" },
+    ): ConfigurableTestObject => {
+        const testObject = new ConfigurableTestObject({
+            title: "default-title",
+            file: "/default-file",
+            id: "default-id",
+        });
+        testObject.browserId = browserId;
+
+        return testObject;
+    };
+
+    const applyTraps_ = ({ browserId }: { browserId: string }): void => {
+        const testObject = mkTestObject_({ browserId });
+
+        for (let i = 0; i < (TreeBuilder.prototype.addTrap as SinonStub).callCount; ++i) {
+            (TreeBuilder.prototype.addTrap as SinonStub).getCall(i).args[0](testObject);
+        }
+    };
+
+    beforeEach(() => {
+        sandbox.stub(TreeBuilder.prototype, "addTrap");
+        sandbox.stub(ConfigurableTestObject.prototype, "enable");
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    (
+        [
+            ["plain text", (str: string): string => str],
+            ["regular expression", (str: string): RegExp => new RegExp(str)],
+        ] as const
+    ).forEach(([description, mkMatcher]) => {
+        describe(description, () => {
+            describe(".in", () => {
+                it("should be chainable", () => {
+                    const also = mkController_();
+
+                    const res = also.in(mkMatcher("yabro"));
+
+                    assert.equal(res, also);
+                });
+
+                describe("trap", () => {
+                    it("should be set", () => {
+                        mkController_().in(mkMatcher("yabro"));
+
+                        assert.calledOnceWith(TreeBuilder.prototype.addTrap as SinonStub, sinon.match.func);
+                    });
+
+                    it("should not enable test in case of browser mismatch", () => {
+                        mkController_().in(mkMatcher("yabro"));
+
+                        applyTraps_({ browserId: "broya" });
+
+                        assert.notCalled(ConfigurableTestObject.prototype.enable as SinonStub);
+                    });
+
+                    it("should enable test in case of browser match", () => {
+                        mkController_().in(mkMatcher("yabro"));
+
+                        applyTraps_({ browserId: "yabro" });
+
+                        assert.calledOnce(ConfigurableTestObject.prototype.enable as SinonStub);
+                    });
+
+                    it("should enable for each match", () => {
+                        mkController_().in(mkMatcher("yabro")).in(mkMatcher("broya"));
+
+                        applyTraps_({ browserId: "broya" });
+
+                        assert.calledOnce(ConfigurableTestObject.prototype.enable as SinonStub);
+                    });
+
+                    it("should accept few matchers", () => {
+                        mkController_().in([mkMatcher("yabro"), mkMatcher("broya")]);
+
+                        applyTraps_({ browserId: "broya" });
+
+                        assert.calledOnce(ConfigurableTestObject.prototype.enable as SinonStub);
+                    });
+                });
+            });
+        });
+    });
+});

--- a/test/src/test-reader/test-object/configurable-test-object.js
+++ b/test/src/test-reader/test-object/configurable-test-object.js
@@ -153,7 +153,7 @@ describe("test-reader/test-object/configurable-test-object", () => {
         ["disabled", false, true, false],
         ["silentSkip", false, true, false],
         ["timeout", 0, 100500, 500100],
-        ["browserId", undefined, "foo", "bar"],
+        ["browserId", "", "foo", "bar"],
         ["browserVersion", undefined, "100500", "500100"],
     ].forEach(([property, defaultValue, testValue, valueToOverwrite]) => {
         describe(property, () => {

--- a/test/src/test-reader/test-object/configurable-test-object.js
+++ b/test/src/test-reader/test-object/configurable-test-object.js
@@ -147,6 +147,24 @@ describe("test-reader/test-object/configurable-test-object", () => {
         });
     });
 
+    describe("enable", () => {
+        it("should unset disabled property", () => {
+            const obj = mkObj_();
+
+            obj.enable();
+
+            assert.isFalse(obj.disabled);
+        });
+
+        it("should unset silentSkip property", () => {
+            const obj = mkObj_();
+
+            obj.enable();
+
+            assert.isFalse(obj.silentSkip);
+        });
+    });
+
     [
         ["pending", false, true, false],
         ["skipReason", "", "foo bar", "baz qux"],

--- a/test/src/test-reader/test-parser.js
+++ b/test/src/test-reader/test-parser.js
@@ -4,6 +4,7 @@ const { TreeBuilder } = require("src/test-reader/tree-builder");
 const { InstructionsList, Instructions } = require("src/test-reader/build-instructions");
 const { SkipController } = require("src/test-reader/controllers/skip-controller");
 const { OnlyController } = require("src/test-reader/controllers/only-controller");
+const { AlsoController } = require("src/test-reader/controllers/also-controller");
 const { ConfigController } = require("src/test-reader/controllers/config-controller");
 const { TestParserAPI } = require("src/test-reader/test-parser-api");
 const { Test, Suite } = require("src/test-reader/test-object");
@@ -136,6 +137,7 @@ describe("test-reader/test-parser", () => {
             Object.entries({
                 skip: SkipController,
                 only: OnlyController,
+                also: AlsoController,
             }).forEach(([controllerName, controllerClass]) => {
                 describe(`hermions.${controllerName}`, () => {
                     beforeEach(() => {


### PR DESCRIPTION
### What is done:

- implement ability to specify browser as passive using option "passive: true" in browser config;
- make "browserId" as string for runnables, because I don't see case in which it can be `undefined`;
- add "enable" method for all runnables (use it inside `testplane.also.in`);
- add "also" controller in `global.testplane` in order to be able to run test in passive browser.