### PR TITLE
feat: look for configs in format testplane.config.{ts,js,cts,cjs}

### DIFF
--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -113,4 +113,13 @@ module.exports = {
     passive: false,
 };
 
-module.exports.configPaths = [".testplane.conf.ts", ".testplane.conf.js", ".hermione.conf.ts", ".hermione.conf.js"];
+module.exports.configPaths = [
+    ".testplane.conf.ts",
+    ".testplane.conf.js",
+    "testplane.config.ts",
+    "testplane.config.js",
+    "testplane.config.cts",
+    "testplane.config.cjs",
+    ".hermione.conf.ts",
+    ".hermione.conf.js",
+];


### PR DESCRIPTION
### What is done

- look for configs in format testplane.config.{ts,js,cts,cjs}. Previously, we supported configs in the format `.testplane.conf.{ts,js}`.