### PR TITLE
feat: add "pid" to log info with test result

### DIFF
--- a/src/reporters/utils/helpers.js
+++ b/src/reporters/utils/helpers.js
@@ -23,10 +23,11 @@ exports.formatTestInfo = test => {
     const suiteName = test.fullTitle().replace(test.title, "");
     const sessionId = test.sessionId ? `:${test.sessionId}` : "";
     const reason = test.pending && ` reason: ${chalk.red(getSkipReason(test) || "no comment")}`;
+    const pid = test.meta?.pid ? `, pid:${test.meta.pid}` : "";
 
     return (
         ` ${suiteName}${chalk.underline(test.title)} [${chalk.yellow(test.browserId)}` +
-        `${sessionId}] - ${chalk.cyan(test.duration || 0)}ms${reason || ""}`
+        `${sessionId}${pid}] - ${chalk.cyan(test.duration || 0)}ms${reason || ""}`
     );
 };
 

--- a/test/src/reporters/flat.js
+++ b/test/src/reporters/flat.js
@@ -102,15 +102,26 @@ describe("Flat reporter", () => {
             TEST_FAIL: "failed",
         };
 
-        it("should correctly do the rendering", async () => {
-            test = mkTestStub_({ sessionId: "test_session" });
+        it("should render session id", async () => {
+            test = mkTestStub_({ sessionId: "500100" });
 
             await createFlatReporter();
             emit(RunnerEvents.TEST_PASS, test);
 
             const result = getDeserializedResult(informer.log.firstCall.args[0]);
 
-            assert.equal(result, "suite test [chrome:test_session] - 100500ms");
+            assert.equal(result, "suite test [chrome:500100] - 100500ms");
+        });
+
+        it("should render pid", async () => {
+            test = mkTestStub_({ meta: { pid: "12345" } });
+
+            await createFlatReporter();
+            emit(RunnerEvents.TEST_PASS, test);
+
+            const result = getDeserializedResult(informer.log.firstCall.args[0]);
+
+            assert.equal(result, "suite test [chrome, pid:12345] - 100500ms");
         });
 
         describe("skipped tests report", () => {


### PR DESCRIPTION
## What is done

- add information to log with test result about pid in which test was run.

It will look like this:

```shell
[13:39:22 +0300] ✓ test example [chrome:d049e4a3-903d-489b-8571-2ea8fd7da04b, pid:27200] - 963ms
```