### PR TITLE
fix: error on assertView when viewport has fractional values

### DIFF
--- a/src/browser/client-scripts/index.js
+++ b/src/browser/client-scripts/index.js
@@ -139,6 +139,7 @@ function prepareScreenshotUnsafe(areas, opts) {
             width: viewportWidth,
             height: viewportHeight
         })
+            .round()
             .scale(pixelRatio)
             .serialize(),
         documentHeight: Math.ceil(documentHeight * pixelRatio),


### PR DESCRIPTION
Error looks like: Image to composite must have same dimensions or smaller