### PR TITLE
fix: revert round of viewport

### DIFF
--- a/src/browser/client-scripts/index.js
+++ b/src/browser/client-scripts/index.js
@@ -80,7 +80,7 @@ function prepareScreenshotUnsafe(areas, opts) {
             top: util.getScrollTop(scrollElem),
             width: viewportWidth,
             height: viewportHeight
-        }).round(),
+        }),
         pixelRatio = configurePixelRatio(opts.usePixelRatio),
         rect,
         selectors = [];


### PR DESCRIPTION
### What is done

Revert change from - https://github.com/gemini-testing/testplane/pull/928. The problem is that after this change, an error occurs under certain conditions: `Image to composite must have same dimensions or smaller`. I solved this error in this PR - https://github.com/gemini-testing/testplane/pull/992, but I can't merge it, because it leads to differences in screenshots (when viewport has fractional dimensions).

Because of this, I am rolling back the old change and we will implement it back in the next major - testplane@9.