### PR TITLE
fix: use propper unhandled rejection error serialization

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const _ = require("lodash");
+const util = require("util");
 const { Command } = require("@gemini-testing/commander");
 const escapeRe = require("escape-string-regexp");
 
@@ -15,7 +15,7 @@ const { shouldIgnoreUnhandledRejection } = require("../utils/errors");
 let testplane;
 
 process.on("uncaughtException", err => {
-    logger.error(err.stack);
+    logger.error(util.inspect(err));
     process.exit(1);
 });
 
@@ -27,8 +27,8 @@ process.on("unhandledRejection", (reason, p) => {
 
     const error = [
         `Unhandled Rejection in testplane:master:${process.pid}:`,
-        `Promise: ${JSON.stringify(p)}`,
-        `Reason: ${_.get(reason, "stack", reason)}`,
+        `Promise: ${util.inspect(p)}`,
+        `Reason: ${util.inspect(reason)}`,
     ].join("\n");
 
     if (testplane) {

--- a/src/utils/processor.js
+++ b/src/utils/processor.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const _ = require("lodash");
+const util = require("util");
 const { WORKER_UNHANDLED_REJECTION } = require("../constants/process-messages");
 const logger = require("./logger");
 const ipc = require("./ipc");
@@ -14,8 +15,8 @@ process.on("unhandledRejection", (reason, p) => {
 
     const error = [
         `Unhandled Rejection in testplane:worker:${process.pid}:`,
-        `Promise: ${JSON.stringify(p)}`,
-        `Reason: ${_.get(reason, "stack", reason)}`,
+        `Promise: ${util.inspect(p)}`,
+        `Reason: ${util.inspect(reason)}`,
     ].join("\n");
 
     ipc.emit(WORKER_UNHANDLED_REJECTION, { error });


### PR DESCRIPTION
As `JSON.stringify` of `Error` is `{}`, it is not the best thing to use, as well as `String(Error)`, which does not include "stack"

`util.inspect` solves the problem.