### PR TITLE
fix: restore passive browsers html-reporter compatibility

### DIFF
--- a/src/test-reader/controllers/also-controller.ts
+++ b/src/test-reader/controllers/also-controller.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events";
 import { TestReaderEvents as ReadEvents } from "../../events";
-import type { Test } from "../../types";
+import type { Test, Suite } from "../../types";
 
 interface TreeBuilder {
     addTrap: (trap: (test: Test) => void) => void;
@@ -28,6 +28,14 @@ export class AlsoController {
             treeBuilder.addTrap(obj => {
                 if (match(obj.browserId)) {
                     obj.enable();
+
+                    let objParent: Suite | null = obj.parent;
+
+                    while (objParent) {
+                        objParent.enable();
+
+                        objParent = objParent.parent;
+                    }
                 }
             });
         });


### PR DESCRIPTION
We suggest people to move from "hermione-passive-browsers" to "passive", but "passive" doesn't work with html-reporter gui.

In html-reporter gui, we skip all tests, which has `silentlySkipped: true`: https://github.com/gemini-testing/html-reporter/blob/30d8ec99835bf35a0aa14b2437d3ad7fbc76ba79/lib/gui/tool-runner/index.ts#L337

And `Testplane` returns `silentlySkipped` as "is any of nested parents is skipped": https://github.com/gemini-testing/testplane/blob/61813709ea160b6568cc175dced61936200b5de0/src/runner/test-runner/skipped-test-runner.js#L23

So, in order for passive browsers to work, we need to enable all parent suites of tests, enabled with ".also.in"