### PR TITLE
chore: update plugins-loader from 1.3.3 to 1.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "looks-same": "9.0.1",
         "micromatch": "4.0.5",
         "mocha": "10.2.0",
-        "plugins-loader": "1.3.3",
+        "plugins-loader": "1.3.4",
         "png-validator": "1.1.0",
         "resolve.exports": "2.0.2",
         "sharp": "0.32.6",
@@ -13072,9 +13072,9 @@
       }
     },
     "node_modules/plugins-loader": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/plugins-loader/-/plugins-loader-1.3.3.tgz",
-      "integrity": "sha512-ByG2rWfPgLCZnv82c+Whth4jpUDklzrrAMheGKCRTZOnrR4t+rasnonjdVYqdDgbJ3EaGSQiujI96fyxiGAp0g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/plugins-loader/-/plugins-loader-1.3.4.tgz",
+      "integrity": "sha512-JOt9iotacEz9QwvQm7PWk8d71jsigf/ko4UAwkPZKCFGWRzYAuSZ89eJpg1Jp3CAVLOLA5Rhp7rf885ANIEdTw==",
       "dependencies": {
         "lodash": "^4.16.4"
       }
@@ -26374,9 +26374,9 @@
       "dev": true
     },
     "plugins-loader": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/plugins-loader/-/plugins-loader-1.3.3.tgz",
-      "integrity": "sha512-ByG2rWfPgLCZnv82c+Whth4jpUDklzrrAMheGKCRTZOnrR4t+rasnonjdVYqdDgbJ3EaGSQiujI96fyxiGAp0g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/plugins-loader/-/plugins-loader-1.3.4.tgz",
+      "integrity": "sha512-JOt9iotacEz9QwvQm7PWk8d71jsigf/ko4UAwkPZKCFGWRzYAuSZ89eJpg1Jp3CAVLOLA5Rhp7rf885ANIEdTw==",
       "requires": {
         "lodash": "^4.16.4"
       }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "looks-same": "9.0.1",
     "micromatch": "4.0.5",
     "mocha": "10.2.0",
-    "plugins-loader": "1.3.3",
+    "plugins-loader": "1.3.4",
     "png-validator": "1.1.0",
     "resolve.exports": "2.0.2",
     "sharp": "0.32.6",


### PR DESCRIPTION
In order to support all yarn versions. More info here - https://github.com/gemini-testing/plugins-loader/pull/14