### PR TITLE
fix: stop REPL servers on call "halt" method

### DIFF
--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -8,3 +8,7 @@ testplaneFacade.init();
 exports.runTest = (fullTitle, options) => {
     return testplaneFacade.runTest(fullTitle, options);
 };
+
+exports.cancel = () => {
+    return testplaneFacade.cancel();
+};

--- a/src/worker/testplane-facade.ts
+++ b/src/worker/testplane-facade.ts
@@ -31,6 +31,10 @@ module.exports = class TestplaneFacade {
         return this.promise;
     }
 
+    cancel(): void {
+        RuntimeConfig.getInstance().replServer?.close();
+    }
+
     syncConfig(): Promise<void> {
         this.syncConfig = (): Promise<void> => this.promise;
 

--- a/test/src/runner/index.js
+++ b/test/src/runner/index.js
@@ -23,6 +23,7 @@ describe("NodejsEnvRunner", () => {
     const mkWorkers_ = () => {
         return {
             runTest: sandbox.stub().resolves(),
+            cancel: sandbox.stub().resolves(),
         };
     };
 
@@ -693,6 +694,17 @@ describe("NodejsEnvRunner", () => {
 
             assert.notCalled(BrowserRunner.prototype.run);
             assert.notCalled(BrowserRunner.prototype.cancel);
+        });
+
+        it("should cancel all executing workers", async () => {
+            const workers = mkWorkers_();
+            WorkersRegistry.prototype.register.withArgs(sinon.match.string, ["runTest", "cancel"]).returns(workers);
+            const runner = new Runner(makeConfigStub());
+
+            runner.init();
+            runner.cancel();
+
+            assert.calledOnceWithExactly(workers.cancel);
         });
     });
 });

--- a/test/src/worker/index.js
+++ b/test/src/worker/index.js
@@ -43,4 +43,29 @@ describe("worker", () => {
             return assert.isRejected(runTest("fullTitle", { some: "opts" }), /foo/);
         });
     });
+
+    describe("cancel", () => {
+        let cancel;
+
+        beforeEach(() => {
+            TestplaneFacade.prototype.cancel.returns();
+
+            const worker = require("src/worker");
+            cancel = worker.cancel;
+        });
+
+        it("should delegate cancel call to testplane facade", () => {
+            TestplaneFacade.prototype.cancel.returns();
+
+            cancel();
+
+            assert.calledOnceWithExactly(TestplaneFacade.prototype.cancel);
+        });
+
+        it("should throws on testplane facade cancel fail", () => {
+            TestplaneFacade.prototype.cancel.throws(new Error("o.O"));
+
+            assert.throws(() => cancel(), Error, "o.O");
+        });
+    });
 });

--- a/test/src/worker/testplane-facade.js
+++ b/test/src/worker/testplane-facade.js
@@ -3,6 +3,7 @@
 const proxyquire = require("proxyquire");
 const { AsyncEmitter } = require("src/events/async-emitter");
 const { Testplane } = require("src/worker/testplane");
+const RuntimeConfig = require("src/config/runtime-config");
 const { makeConfigStub } = require("../../utils");
 const ipc = require("src/utils/ipc");
 const TestplaneFacade = require("src/worker/testplane-facade");
@@ -77,6 +78,25 @@ describe("worker/testplane-facade", () => {
             await testplaneFacade.runTest();
 
             assert.callOrder(TestplaneFacade.prototype.syncConfig, testplane.runTest);
+        });
+    });
+
+    describe("cancel", () => {
+        beforeEach(() => {
+            sandbox.stub(RuntimeConfig, "getInstance").returns({});
+        });
+
+        it("should not throw if repl server is not exists in runtime config", () => {
+            assert.doesNotThrow(() => testplaneFacade.cancel());
+        });
+
+        it("should close repl server if it exists in runtime config", () => {
+            const replServer = { close: sandbox.stub() };
+            RuntimeConfig.getInstance.returns({ replServer });
+
+            testplaneFacade.cancel();
+
+            assert.calledOnceWithExactly(replServer.close);
         });
     });
 });


### PR DESCRIPTION
## What is done

In the case when the user switches to REPL mode and then someone calls `halt` method, then Testplane does not end correctly. In this case, it is necessary to explicitly close the repl server in worker. So I did it.