### PR TITLE
fix(component-testing): correctly import components with css from third party libraries

### DIFF
--- a/src/utils/module.ts
+++ b/src/utils/module.ts
@@ -6,3 +6,7 @@ export const requireModule = async <T = unknown>(modulePath: string): Promise<T>
 
     return require(isModuleLocal ? path.resolve(modulePath) : modulePath);
 };
+
+export const requireModuleSync = (modulePath: string): unknown => {
+    return require(modulePath);
+};

--- a/test/src/test-reader/test-transformer.ts
+++ b/test/src/test-reader/test-transformer.ts
@@ -1,5 +1,6 @@
 import * as pirates from "pirates";
 import sinon, { SinonStub } from "sinon";
+import proxyquire from "proxyquire";
 import { setupTransformHook, TRANSFORM_EXTENSIONS } from "../../../src/test-reader/test-transformer";
 
 describe("test-transformer", () => {
@@ -59,29 +60,81 @@ describe("test-transformer", () => {
             });
         });
 
-        [true, false].forEach(removeNonJsImports => {
-            describe(`should ${removeNonJsImports ? "" : "not "}remove non-js imports`, () => {
-                [".css", ".less", ".scss", ".jpg", ".png", ".woff"].forEach(extName => {
-                    it(`asset with extension: "${extName}"`, () => {
-                        let transformedCode;
-                        const fileName = `some${extName}`;
-                        (pirates.addHook as SinonStub).callsFake(cb => {
-                            transformedCode = cb(`import "${fileName}"`, fileName);
+        describe("'removeNonJsImports' option", () => {
+            [true, false].forEach(removeNonJsImports => {
+                describe(`should ${removeNonJsImports ? "" : "not "}remove non-js imports`, () => {
+                    [".css", ".less", ".scss", ".jpg", ".png", ".woff"].forEach(extName => {
+                        it(`asset with extension: "${extName}"`, () => {
+                            let transformedCode;
+                            const fileName = `some${extName}`;
+                            (pirates.addHook as SinonStub).callsFake(cb => {
+                                transformedCode = cb(`import "${fileName}"`, fileName);
+                            });
+
+                            setupTransformHook({ removeNonJsImports });
+
+                            const expectedCode = ['"use strict";'];
+
+                            if (!removeNonJsImports) {
+                                expectedCode.push("", `require("some${extName}");`);
+                            }
+
+                            expectedCode.push("//# sourceMappingURL=");
+
+                            assert.match(transformedCode, expectedCode.join("\n"));
                         });
-
-                        setupTransformHook({ removeNonJsImports });
-
-                        const expectedCode = ['"use strict";'];
-
-                        if (!removeNonJsImports) {
-                            expectedCode.push("", `require("some${extName}");`);
-                        }
-
-                        expectedCode.push("//# sourceMappingURL=");
-
-                        assert.match(transformedCode, expectedCode.join("\n"));
                     });
                 });
+            });
+
+            describe("should remove third party import with error from", () => {
+                [".css", ".less", ".scss", ".sass", ".styl", ".stylus", ".pcss"].forEach(extName => {
+                    it(`${extName} style file`, () => {
+                        const moduleName = "some-module";
+                        const error = { message: "Unexpected token {", stack: `foo${extName}:100500\nbar\nqux` };
+
+                        const { setupTransformHook } = proxyquire("../../../src/test-reader/test-transformer", {
+                            "../bundle": proxyquire.noCallThru().load("../../../src/bundle/test-transformer", {
+                                "../utils/module": {
+                                    requireModuleSync: sandbox.stub().withArgs(moduleName).throws(error),
+                                },
+                            }),
+                        });
+
+                        let transformedCode;
+
+                        (pirates.addHook as SinonStub).callsFake(cb => {
+                            transformedCode = cb(`import "${moduleName}"`, moduleName);
+                        });
+
+                        setupTransformHook({ removeNonJsImports: true });
+
+                        assert.notMatch(transformedCode, new RegExp(`require\\("${moduleName}"\\)`));
+                    });
+                });
+            });
+
+            it("should not remove third party import with error not from style file", () => {
+                const moduleName = "some-module";
+                const error = { message: "Some error", stack: `foo.js:100500\nbar\nqux` };
+
+                const { setupTransformHook } = proxyquire("../../../src/test-reader/test-transformer", {
+                    "../bundle": proxyquire.noCallThru().load("../../../src/bundle/test-transformer", {
+                        "../utils/module": {
+                            requireModuleSync: sandbox.stub().withArgs(moduleName).throws(error),
+                        },
+                    }),
+                });
+
+                let transformedCode;
+
+                (pirates.addHook as SinonStub).callsFake(cb => {
+                    transformedCode = cb(`import "${moduleName}"`, moduleName);
+                });
+
+                setupTransformHook({ removeNonJsImports: true });
+
+                assert.match(transformedCode, new RegExp(`require\\("${moduleName}"\\)`));
             });
         });
     });


### PR DESCRIPTION
### What is done

Some libraries can load css files when you import them in component test file. For example:
```
// test.testplane.tsx
import {Button} from "some-component-library";

describe("suite", {...});
```

This file executes not only in browser, but also in nodejs environment. Where I get an error like: `Unexpected token ...` when try to import it. To solve this problem we use pirates + babel, they remove unnecessary imports. But when user import some module (without file extension) we can't figure out if it needs to be ignored in node env or not.

So in order to fix this problem we first require this module and if we get `Unexpected token ...` error from css file then we remove it.