### PR TITLE
fix: correctly define screenshotsDir option for browsers

### DIFF
--- a/src/config/browser-options.js
+++ b/src/config/browser-options.js
@@ -189,14 +189,19 @@ function buildBrowserOptions(defaultFactory, extra) {
                     throw new Error('"screenshotsDir" must be a string or function');
                 }
             },
-            map: (value, _, __, { isSetByUser }) => {
-                const deprecatedScreensPath = "hermione/screens";
-
-                if (!isSetByUser && fs.existsSync(deprecatedScreensPath) && !fs.existsSync(value)) {
-                    return deprecatedScreensPath;
+            map: (value, config, __, { isSetByUser }) => {
+                if (isSetByUser) {
+                    return value;
                 }
 
-                return value;
+                const topLevelScreenshotsDir = _.get(config, "screenshotsDir");
+                if (topLevelScreenshotsDir) {
+                    return topLevelScreenshotsDir;
+                }
+
+                const deprecatedScreensPath = "hermione/screens";
+
+                return fs.existsSync(deprecatedScreensPath) && !fs.existsSync(value) ? deprecatedScreensPath : value;
             },
         }),
 

--- a/test/src/config/browser-options.js
+++ b/test/src/config/browser-options.js
@@ -531,7 +531,11 @@ describe("config browser-options", () => {
         });
 
         it("should fallback default value to hermione/screens, if it exists and default dir not exists", () => {
-            const readConfig = {};
+            const readConfig = {
+                browsers: {
+                    b1: mkBrowser_(),
+                },
+            };
             Config.read.returns(readConfig);
             sandbox
                 .stub(fs, "existsSync")
@@ -543,10 +547,15 @@ describe("config browser-options", () => {
             const config = createConfig();
 
             assert.equal(config.screenshotsDir, "hermione/screens");
+            assert.equal(config.browsers.b1.screenshotsDir, "hermione/screens");
         });
 
         it("should use default testplane/screens if both hermione/screens and testplane/screens exists", () => {
-            const readConfig = {};
+            const readConfig = {
+                browsers: {
+                    b1: mkBrowser_(),
+                },
+            };
             Config.read.returns(readConfig);
             sandbox
                 .stub(fs, "existsSync")
@@ -558,10 +567,15 @@ describe("config browser-options", () => {
             const config = createConfig();
 
             assert.equal(config.screenshotsDir, "testplane/screens");
+            assert.equal(config.browsers.b1.screenshotsDir, "testplane/screens");
         });
 
         it("should not fallback default value to hermione/screens, if not exists", () => {
-            const readConfig = {};
+            const readConfig = {
+                browsers: {
+                    b1: mkBrowser_(),
+                },
+            };
             Config.read.returns(readConfig);
             sandbox
                 .stub(fs, "existsSync")
@@ -573,10 +587,16 @@ describe("config browser-options", () => {
             const config = createConfig();
 
             assert.equal(config.screenshotsDir, "testplane/screens");
+            assert.equal(config.browsers.b1.screenshotsDir, "testplane/screens");
         });
 
         it("should not fallback value to hermione/screens, if defined", () => {
-            const readConfig = { screenshotsDir: "some/dir" };
+            const readConfig = {
+                screenshotsDir: "some/dir",
+                browsers: {
+                    b1: mkBrowser_({ screenshotsDir: "another/dir" }),
+                },
+            };
             Config.read.returns(readConfig);
             sandbox
                 .stub(fs, "existsSync")
@@ -588,6 +608,7 @@ describe("config browser-options", () => {
             const config = createConfig();
 
             assert.equal(config.screenshotsDir, "some/dir");
+            assert.equal(config.browsers.b1.screenshotsDir, "another/dir");
         });
     });
 


### PR DESCRIPTION
### What is done

The screenshotsDir field is not parsed correctly for browsers if the user uses the deprecated value (hermione/screens) and the field itself is specified at the top level (i.e. not inside any browser).