### PR TITLE
fix: fix firefox rrweb recordings and track color scheme changes

### DIFF
--- a/src/browser/history/index.ts
+++ b/src/browser/history/index.ts
@@ -78,7 +78,7 @@ const runWithHistoryHooks = <T>({ session, callstack, nodeData, fn, config }: Ru
                 const shouldRecord = shouldRecordSnapshots(recordMode, isRetry);
 
                 let rrwebEvents: eventWithTime[] = [];
-                if (shouldRecord && process.send && session.executionContext?.titlePath?.()) {
+                if (shouldRecord && process.send && session.executionContext?.ctx?.currentTest) {
                     rrwebEvents = await installRrwebAndCollectEvents(session, callstack);
                 }
 


### PR DESCRIPTION
## What's done?

- Fixed snapshots not being recorded in firefox, because this in `eval()` was pointing to sandbox. In `window.eval()` it works fine.
- Added color scheme changes tracking, which allows us to record whether user has dark theme enabled or not.