### PR TITLE
fix: throw error if chrome not support bidi protocol

### DIFF
--- a/src/constants/browser.ts
+++ b/src/constants/browser.ts
@@ -1,2 +1,15 @@
 export const MIN_CHROME_VERSION_SUPPORT_ISOLATION = 93;
+export const MIN_CHROME_VERSION_SUPPORT_BIDI = 128;
+export const MIN_FIREFOX_VERSION_SUPPORT_BIDI = 119;
 export const X_REQUEST_ID_DELIMITER = "__";
+
+export const BROWSERS_SUPPORT_BIDI = [
+    {
+        name: "chrome",
+        minVersion: MIN_CHROME_VERSION_SUPPORT_BIDI,
+    },
+    {
+        name: "firefox",
+        minVersion: MIN_FIREFOX_VERSION_SUPPORT_BIDI,
+    },
+];


### PR DESCRIPTION
### What is done

Chrome@127 and lower doesn't have feature that used inside webdriverio. So when you open url in that browser you got an error: `Navigation to 'https://webdriver.io' timed out as no request payload was received`. According to this error, it is not clear what the problem is. Therefore, when parsing the config, I throw an error if used chrome@127 and lower with BiDi protocol (specified `webSocketUrl: true` capability)