### PR TITLE
chore(ci): setup pkg.pr.new

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,3 +27,7 @@ jobs:
                   cache: "npm"
             - run: npm ci
             - run: npm test
+
+            - name: Publish
+              if: ${{ startsWith(matrix.node-version, '20') }}
+              run: npx pkg-pr-new publish


### PR DESCRIPTION
### What is done:

- enable pkg.pr.new - https://github.com/stackblitz-labs/pkg.pr.new in order to trigger release in PR without publishing anything to npm