### PR TITLE
chore: up @testplane/webdriverio from to 9.5.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@testplane/devtools": "8.32.3",
         "@testplane/wdio-protocols": "9.4.6",
         "@testplane/wdio-utils": "9.5.3",
-        "@testplane/webdriverio": "9.5.17",
+        "@testplane/webdriverio": "9.5.19",
         "@vitest/spy": "2.1.4",
         "bluebird": "3.5.1",
         "chalk": "2.4.2",
@@ -2767,9 +2767,9 @@
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/@testplane/webdriverio": {
-      "version": "9.5.17",
-      "resolved": "https://registry.npmjs.org/@testplane/webdriverio/-/webdriverio-9.5.17.tgz",
-      "integrity": "sha512-JyLj6iCDQ/EYMe4K/+G6R8sTYbF8ffpEcfdUd5+cDJwsq9PCf4Opz6lD+FbqgHhiNqPbrYX4eheeyYKKFkOR8Q==",
+      "version": "9.5.19",
+      "resolved": "https://registry.npmjs.org/@testplane/webdriverio/-/webdriverio-9.5.19.tgz",
+      "integrity": "sha512-Vvpiab9x8nsUUvM7JREAu+V5NkHIcA+h3hiCNxz5wKu8bNHmNN9uRa21Rr/VJ30OM8YJBGIAdpVWIRF0NzXeoQ==",
       "dependencies": {
         "@testplane/wdio-config": "9.5.3",
         "@testplane/wdio-logger": "9.4.6",
@@ -15910,9 +15910,9 @@
       }
     },
     "@testplane/webdriverio": {
-      "version": "9.5.17",
-      "resolved": "https://registry.npmjs.org/@testplane/webdriverio/-/webdriverio-9.5.17.tgz",
-      "integrity": "sha512-JyLj6iCDQ/EYMe4K/+G6R8sTYbF8ffpEcfdUd5+cDJwsq9PCf4Opz6lD+FbqgHhiNqPbrYX4eheeyYKKFkOR8Q==",
+      "version": "9.5.19",
+      "resolved": "https://registry.npmjs.org/@testplane/webdriverio/-/webdriverio-9.5.19.tgz",
+      "integrity": "sha512-Vvpiab9x8nsUUvM7JREAu+V5NkHIcA+h3hiCNxz5wKu8bNHmNN9uRa21Rr/VJ30OM8YJBGIAdpVWIRF0NzXeoQ==",
       "requires": {
         "@testplane/wdio-config": "9.5.3",
         "@testplane/wdio-logger": "9.4.6",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@testplane/devtools": "8.32.3",
     "@testplane/wdio-protocols": "9.4.6",
     "@testplane/wdio-utils": "9.5.3",
-    "@testplane/webdriverio": "9.5.17",
+    "@testplane/webdriverio": "9.5.19",
     "@vitest/spy": "2.1.4",
     "bluebird": "3.5.1",
     "chalk": "2.4.2",

--- a/src/browser/commands/moveCursorTo.ts
+++ b/src/browser/commands/moveCursorTo.ts
@@ -8,7 +8,7 @@ type MoveToOptions = {
 
 // As of now, we can't export type of the command function directly. See: https://github.com/webdriverio/webdriverio/issues/12527
 export type MoveCursorToCommand = (
-    this: WebdriverIO.Element | ChainablePromiseElement,
+    this: WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element>,
     options: MoveToOptions,
 ) => Promise<void>;
 

--- a/src/browser/commands/types.ts
+++ b/src/browser/commands/types.ts
@@ -17,7 +17,7 @@ export type AssertViewCommandWithoutSelector = (
 export type AssertViewCommand = AssertViewCommandWithSelector & AssertViewCommandWithoutSelector;
 
 export type AssertViewElementCommand = (
-    this: WebdriverIO.Element | ChainablePromiseElement,
+    this: WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element>,
     state: string,
     opts?: AssertViewOpts,
 ) => Promise<void>;

--- a/src/runner/browser-env/vite/browser-modules/expect.ts
+++ b/src/runner/browser-env/vite/browser-modules/expect.ts
@@ -1,7 +1,6 @@
 import { expect, type Expect } from "expect";
 import { ASYMMETRIC_MATCHER } from "./constants.js";
 import { BrowserEventNames, type BrowserRunExpectMatcherPayload, MockMatcherFn } from "./types.js";
-import type { ChainablePromiseElement } from "@testplane/webdriverio";
 
 export const initExpect = (): Expect => {
     const mockedMatchers = mockMatchers(window.__testplane__.expectMatchers);
@@ -50,8 +49,8 @@ function mockMatcher(matcherName: string): MockMatcherFn {
         /**
          * Check if context is ChainablePromiseElement
          */
-        if (isContextObject && typeof (context as { selector: string }).selector === "object") {
-            matcherPayload.element = (await context) as ChainablePromiseElement;
+        if (isContextObject && "then" in context && typeof context.selector === "object") {
+            matcherPayload.element = await context;
         }
 
         /**

--- a/src/runner/browser-env/vite/browser-modules/types.ts
+++ b/src/runner/browser-env/vite/browser-modules/types.ts
@@ -27,8 +27,12 @@ export interface BrowserRunExpectMatcherPayload {
     name: string;
     scope: MatcherState;
     args: unknown[];
-    element?: WebdriverIO.Element | ChainablePromiseElement;
-    context?: WebdriverIO.Browser | WebdriverIO.Element | WebdriverIO.ElementArray | ChainablePromiseElement;
+    element?: WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element>;
+    context?:
+        | WebdriverIO.Browser
+        | WebdriverIO.Element
+        | WebdriverIO.ElementArray
+        | ChainablePromiseElement<WebdriverIO.Element>;
 }
 
 export interface BrowserCallConsoleMethodPayload {

--- a/src/worker/browser-env/runner/test-runner/index.ts
+++ b/src/worker/browser-env/runner/test-runner/index.ts
@@ -279,10 +279,10 @@ export class TestRunner extends NodejsEnvTestRunner {
 
                 if (payload.element) {
                     if (_.isArray(payload.element)) {
-                        context = (await session.$$(payload.element)) as unknown as WebdriverIO.ElementArray;
+                        context = await session.$$(payload.element);
                     } else if (payload.element.elementId) {
                         context = await session.$(payload.element);
-                        context.selector = payload.element.selector as Promise<Selector>;
+                        context.selector = payload.element.selector as Selector;
                     } else {
                         context = await session.$(payload.element.selector as Selector);
                     }
@@ -339,17 +339,17 @@ function transformExpectArg(arg: any): unknown {
 
 async function getWdioInstance(
     session: WebdriverIO.Browser,
-    element?: WebdriverIO.Element,
-): Promise<WebdriverIO.Browser | ChainablePromiseElement> {
+    element?: WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element>,
+): Promise<WebdriverIO.Browser | ChainablePromiseElement<WebdriverIO.Element>> {
     const wdioInstance = element ? await session.$(element) : session;
 
     if (isWdioElement(wdioInstance) && !wdioInstance.selector) {
-        wdioInstance.selector = element?.selector as unknown as Promise<Selector>;
+        wdioInstance.selector = element?.selector as Selector;
     }
 
     return wdioInstance;
 }
 
-function isWdioElement(ctx: WebdriverIO.Browser | ChainablePromiseElement): ctx is ChainablePromiseElement {
-    return Boolean((ctx as ChainablePromiseElement).elementId);
+function isWdioElement(ctx: WebdriverIO.Browser | WebdriverIO.Element): ctx is WebdriverIO.Element {
+    return Boolean((ctx as WebdriverIO.Element).elementId);
 }

--- a/test/src/worker/browser-env/runner/test-runner/index.ts
+++ b/test/src/worker/browser-env/runner/test-runner/index.ts
@@ -840,7 +840,7 @@ describe("worker/browser-env/runner/test-runner", () => {
                 });
 
                 it("context as an elements array", done => {
-                    const elements = ["elem1", "elem2"] as unknown as ChainablePromiseElement;
+                    const elements = ["elem1", "elem2"] as unknown as ChainablePromiseElement<WebdriverIO.Element>;
                     const elementsRes = ["elem1_res", "elem2_res"];
                     const browser = mkBrowser_();
                     browser.publicAPI.$$ = sandbox.stub().withArgs(elements).resolves(elementsRes);


### PR DESCRIPTION
### What is done

- move to @testplane/webdriverio@9.5.19
- return previous types which was modified in https://github.com/gemini-testing/testplane/pull/1067, because in new version of wdio I fixed some bugs