### PR TITLE
feat: ability to keep browser after tests are done executing (#1096)

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -7,3 +7,62 @@ Testpalne supports [OpenTelemetry](https://opentelemetry.io) standard for tracin
 
 You can use `traceparent` to trace the execution of individual tests.
 
+### Keep Browser for Debugging
+
+Testplane provides CLI options to keep browser sessions alive after test completion for debugging purposes. This feature has two main use cases:
+
+1. **Local debugging**: After test fails, you can still interact with the browser and see what's wrong
+2. **AI agents integration**: Let AI agents run tests to perform complex logic (e.g. custom authentication), then attach to browser via MCP and perform additional actions
+
+#### Why not REPL?
+
+While REPL mode pauses test execution for interactive debugging, keep-browser options preserve the final browser state after tests finish. For AI agents, it's much easier to say "write test with the same beforeEach as in this file and run it to prepare browser" rather than forcing AI to use REPL interactively.
+
+#### `--keep-browser`
+
+Keep browser session alive after test completion for debugging.
+
+```bash
+npx testplane --keep-browser --browser chrome tests/login.test.js
+```
+
+#### `--keep-browser-on-fail`
+
+Keep browser session alive only when test fails for debugging.
+
+```bash
+npx testplane --keep-browser-on-fail --browser chrome tests/login.test.js
+```
+
+**Note**: These options work only when running a single test in a single browser.
+
+#### Session Information
+
+When a browser is kept alive, Testplane outputs a message with session information for programmatic access:
+
+```
+Testplane run has finished, but the browser won't be closed, because you passed the --keep-browser argument.
+You may attach to this browser using the following capabilities:
+{
+    "sessionId": "abc123...",
+    "capabilities": {
+        "browserName": "chrome",
+        "debuggerAddress": "127.0.0.1:9222"
+    },
+    "sessionOptions": {
+        "hostname": "127.0.0.1",
+        "port": 4444,
+        "path": "/wd/hub",
+        "protocol": "http"
+    }
+}
+```
+
+#### Attaching to Kept Session
+
+You can use the outputted session information to attach to the kept browser through:
+
+- **MCP (Model Context Protocol)** tools that support WebDriver session attachment
+- **CDP (Chrome DevTools Protocol)** using the `debuggerAddress` from capabilities
+- **Direct WebDriver** connection using the session ID and connection details
+- **Custom automation tools** that can reuse existing browser sessions 

--- a/src/browser-installer/chrome/index.ts
+++ b/src/browser-installer/chrome/index.ts
@@ -7,13 +7,14 @@ import { getMilestone } from "../utils";
 import { installChrome, resolveLatestChromeVersion } from "./browser";
 import { installChromeDriver } from "./driver";
 import { isUbuntu, getUbuntuLinkerEnv } from "../ubuntu-packages";
+import RuntimeConfig from "../../config/runtime-config";
 
 export { installChrome, resolveLatestChromeVersion, installChromeDriver };
 
 export const runChromeDriver = async (
     chromeVersion: string,
     { debug = false } = {},
-): Promise<{ gridUrl: string; process: ChildProcess; port: number }> => {
+): Promise<{ gridUrl: string; process: ChildProcess; port: number; kill: () => void }> => {
     const [chromeDriverPath, randomPort, chromeDriverEnv] = await Promise.all([
         installChromeDriver(chromeVersion),
         getPort(),
@@ -22,9 +23,12 @@ export const runChromeDriver = async (
             .then(extraEnv => (extraEnv ? { ...process.env, ...extraEnv } : process.env)),
     ]);
 
+    const runtimeConfig = RuntimeConfig.getInstance();
+    const keepBrowserModeEnabled = runtimeConfig.keepBrowserMode.enabled;
+
     const chromeDriver = spawn(chromeDriverPath, [`--port=${randomPort}`, debug ? `--verbose` : "--silent"], {
         windowsHide: true,
-        detached: false,
+        detached: keepBrowserModeEnabled || false,
         env: chromeDriverEnv,
     });
 
@@ -34,9 +38,16 @@ export const runChromeDriver = async (
 
     const gridUrl = `http://127.0.0.1:${randomPort}`;
 
-    process.once("exit", () => chromeDriver.kill());
+    if (!keepBrowserModeEnabled) {
+        process.once("exit", () => chromeDriver.kill());
+    }
 
     await waitPort({ port: randomPort, output: "silent", timeout: DRIVER_WAIT_TIMEOUT });
 
-    return { gridUrl, process: chromeDriver, port: randomPort };
+    return {
+        gridUrl,
+        process: chromeDriver,
+        port: randomPort,
+        kill: () => chromeDriver.kill(),
+    };
 };

--- a/src/browser-installer/edge/index.ts
+++ b/src/browser-installer/edge/index.ts
@@ -4,6 +4,7 @@ import getPort from "get-port";
 import waitPort from "wait-port";
 import { pipeLogsWithPrefix } from "../../dev-server/utils";
 import { DRIVER_WAIT_TIMEOUT } from "../constants";
+import RuntimeConfig from "../../config/runtime-config";
 
 export { resolveEdgeVersion } from "./browser";
 export { installEdgeDriver };
@@ -11,12 +12,15 @@ export { installEdgeDriver };
 export const runEdgeDriver = async (
     edgeVersion: string,
     { debug = false }: { debug?: boolean } = {},
-): Promise<{ gridUrl: string; process: ChildProcess; port: number }> => {
+): Promise<{ gridUrl: string; process: ChildProcess; port: number; kill: () => void }> => {
     const [edgeDriverPath, randomPort] = await Promise.all([installEdgeDriver(edgeVersion), getPort()]);
+
+    const runtimeConfig = RuntimeConfig.getInstance();
+    const keepBrowserModeEnabled = runtimeConfig.keepBrowserMode.enabled;
 
     const edgeDriver = spawn(edgeDriverPath, [`--port=${randomPort}`, debug ? `--verbose` : "--silent"], {
         windowsHide: true,
-        detached: false,
+        detached: keepBrowserModeEnabled || false,
     });
 
     if (debug) {
@@ -25,9 +29,11 @@ export const runEdgeDriver = async (
 
     const gridUrl = `http://127.0.0.1:${randomPort}`;
 
-    process.once("exit", () => edgeDriver.kill());
+    if (!keepBrowserModeEnabled) {
+        process.once("exit", () => edgeDriver.kill());
+    }
 
     await waitPort({ port: randomPort, output: "silent", timeout: DRIVER_WAIT_TIMEOUT });
 
-    return { gridUrl, process: edgeDriver, port: randomPort };
+    return { gridUrl, process: edgeDriver, port: randomPort, kill: () => edgeDriver.kill() };
 };

--- a/src/browser-installer/firefox/index.ts
+++ b/src/browser-installer/firefox/index.ts
@@ -7,13 +7,14 @@ import { installLatestGeckoDriver } from "./driver";
 import { pipeLogsWithPrefix } from "../../dev-server/utils";
 import { DRIVER_WAIT_TIMEOUT } from "../constants";
 import { getUbuntuLinkerEnv, isUbuntu } from "../ubuntu-packages";
+import RuntimeConfig from "../../config/runtime-config";
 
 export { installFirefox, resolveLatestFirefoxVersion, installLatestGeckoDriver };
 
 export const runGeckoDriver = async (
     firefoxVersion: string,
     { debug = false } = {},
-): Promise<{ gridUrl: string; process: ChildProcess; port: number }> => {
+): Promise<{ gridUrl: string; process: ChildProcess; port: number; kill: () => void }> => {
     const [geckoDriverPath, randomPort, geckoDriverEnv] = await Promise.all([
         installLatestGeckoDriver(firefoxVersion),
         getPort(),
@@ -22,13 +23,16 @@ export const runGeckoDriver = async (
             .then(extraEnv => (extraEnv ? { ...process.env, ...extraEnv } : process.env)),
     ]);
 
+    const runtimeConfig = RuntimeConfig.getInstance();
+    const keepBrowserModeEnabled = runtimeConfig.keepBrowserMode.enabled;
+
     const geckoDriver = await startGeckoDriver({
         customGeckoDriverPath: geckoDriverPath,
         port: randomPort,
         log: debug ? "debug" : "fatal",
         spawnOpts: {
             windowsHide: true,
-            detached: false,
+            detached: keepBrowserModeEnabled || false,
             env: geckoDriverEnv,
         },
     });
@@ -39,9 +43,11 @@ export const runGeckoDriver = async (
 
     const gridUrl = `http://127.0.0.1:${randomPort}`;
 
-    process.once("exit", () => geckoDriver.kill());
+    if (!keepBrowserModeEnabled) {
+        process.once("exit", () => geckoDriver.kill());
+    }
 
     await waitPort({ port: randomPort, output: "silent", timeout: DRIVER_WAIT_TIMEOUT });
 
-    return { gridUrl, process: geckoDriver, port: randomPort };
+    return { gridUrl, process: geckoDriver, port: randomPort, kill: () => geckoDriver.kill() };
 };

--- a/src/browser/browser.ts
+++ b/src/browser/browser.ts
@@ -39,6 +39,7 @@ export type BrowserState = {
     testXReqId?: string;
     traceparent?: string;
     isBroken?: boolean;
+    isLastTestFailed?: boolean;
 };
 
 export type CustomCommand = { name: string; elementScope: boolean };
@@ -76,6 +77,7 @@ export class Browser {
         this._state = {
             ...opts.state,
             isBroken: false,
+            isLastTestFailed: false,
         };
         this._customCommands = new Set();
         this._wdPool = opts.wdPool;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -77,6 +77,8 @@ export const run = async (opts: TestplaneRunOpts = {}): Promise<void> => {
         .option("--repl-on-fail [type]", "open repl interface on test fail only", Boolean, false)
         .option("--devtools", "switches the browser to the devtools mode with using CDP protocol")
         .option("--local", "use local browsers, managed by testplane (same as 'gridUrl': 'local')")
+        .option("--keep-browser", "do not close browser session after test completion")
+        .option("--keep-browser-on-fail", "do not close browser session when test fails")
         .arguments("[paths...]")
         .action(async (paths: string[]) => {
             try {
@@ -93,6 +95,8 @@ export const run = async (opts: TestplaneRunOpts = {}): Promise<void> => {
                     replOnFail,
                     devtools,
                     local,
+                    keepBrowser,
+                    keepBrowserOnFail,
                 } = program;
 
                 const isTestsSuccess = await testplane.run(paths, {
@@ -110,6 +114,10 @@ export const run = async (opts: TestplaneRunOpts = {}): Promise<void> => {
                     },
                     devtools: devtools || false,
                     local: local || false,
+                    keepBrowserMode: {
+                        enabled: keepBrowser || keepBrowserOnFail || false,
+                        onFail: keepBrowserOnFail || false,
+                    },
                 });
 
                 process.exit(isTestsSuccess ? 0 : 1);

--- a/src/test-reader/index.ts
+++ b/src/test-reader/index.ts
@@ -62,13 +62,18 @@ export class TestReader extends EventEmitter {
 function validateTests(testsByBro: Record<string, Test[]>, options: TestReaderOpts): void {
     const tests = _.flatten(Object.values(testsByBro));
 
-    if (options.replMode?.enabled) {
+    const singleTestModes = [
+        { condition: options.replMode?.enabled, name: "repl mode" },
+        { condition: options.keepBrowserMode?.enabled, name: "keep-browser mode" },
+    ].filter(mode => mode.condition);
+
+    for (const mode of singleTestModes) {
         const testsToRun = tests.filter(test => !test.disabled && !test.pending);
         const browsersToRun = _.uniq(testsToRun.map(test => test.browserId));
 
         if (testsToRun.length !== 1) {
             throw new Error(
-                `In repl mode only 1 test in 1 browser should be run, but found ${testsToRun.length} tests` +
+                `In ${mode.name} only 1 test in 1 browser should be run, but found ${testsToRun.length} tests` +
                     `${testsToRun.length === 0 ? ". " : ` that run in ${browsersToRun.join(", ")} browsers. `}` +
                     `Try to specify cli-options: "--grep" and "--browser" or use "testplane.only.in" in the test file.`,
             );
@@ -79,7 +84,7 @@ function validateTests(testsByBro: Record<string, Test[]>, options: TestReaderOp
         return;
     }
 
-    const stringifiedOpts = convertOptions(_.omit(options, "replMode"));
+    const stringifiedOpts = convertOptions(_.omit(options, "replMode", "replMode"));
     if (_.isEmpty(stringifiedOpts)) {
         throw new Error(`There are no tests found. Try to specify [${Object.keys(options).join(", ")}] options`);
     } else {

--- a/src/worker/runner/test-runner/index.js
+++ b/src/worker/runner/test-runner/index.js
@@ -93,6 +93,10 @@ module.exports = class TestRunner extends Runner {
                 break;
         }
 
+        if (error && this._browser.state) {
+            this._browser.state.isLastTestFailed = true;
+        }
+
         this._browserAgent.freeBrowser(this._browser);
 
         if (error) {

--- a/test/src/cli/index.js
+++ b/test/src/cli/index.js
@@ -315,6 +315,41 @@ describe("cli", () => {
         });
     });
 
+    describe("keep browser mode", () => {
+        it("should be disabled by default", async () => {
+            await run_();
+
+            assert.calledWithMatch(Testplane.prototype.run, any, {
+                keepBrowserMode: {
+                    enabled: false,
+                    onFail: false,
+                },
+            });
+        });
+
+        it('should be enabled when specify "keep-browser" flag', async () => {
+            await run_("--keep-browser");
+
+            assert.calledWithMatch(Testplane.prototype.run, any, {
+                keepBrowserMode: {
+                    enabled: true,
+                    onFail: false,
+                },
+            });
+        });
+
+        it('should be enabled when specify "keep-browser-on-fail" flag', async () => {
+            await run_("--keep-browser-on-fail");
+
+            assert.calledWithMatch(Testplane.prototype.run, any, {
+                keepBrowserMode: {
+                    enabled: true,
+                    onFail: true,
+                },
+            });
+        });
+    });
+
     it("should turn on devtools mode from cli", async () => {
         await run_("--devtools");
 

--- a/test/src/runner/test-runner/regular-test-runner.js
+++ b/test/src/runner/test-runner/regular-test-runner.js
@@ -11,6 +11,7 @@ const { Test } = require("src/test-reader/test-object");
 const { promiseDelay } = require("../../../../src/utils/promise");
 const { EventEmitter } = require("events");
 const proxyquire = require("proxyquire");
+const RuntimeConfig = require("src/config/runtime-config");
 
 describe("runner/test-runner/regular-test-runner", () => {
     const sandbox = sinon.createSandbox();
@@ -68,6 +69,7 @@ describe("runner/test-runner/regular-test-runner", () => {
         RegularTestRunner = proxyquire("src/runner/test-runner/regular-test-runner", {
             "../../utils/logger": {
                 warn: sandbox.stub(),
+                log: sandbox.stub(),
             },
         });
 
@@ -83,6 +85,8 @@ describe("runner/test-runner/regular-test-runner", () => {
         sandbox.stub(crypto, "randomBytes").callsFake(size => {
             return Buffer.from("11".repeat(size), "hex");
         });
+
+        sandbox.stub(RuntimeConfig, "getInstance").returns({});
     });
 
     afterEach(() => sandbox.restore());
@@ -643,6 +647,78 @@ describe("runner/test-runner/regular-test-runner", () => {
                 delayedEmit();
 
                 assert.calledOnce(BrowserAgent.prototype.freeBrowser);
+            });
+
+            describe("keep-browser mode", () => {
+                it("should not release browser when --keep-browser is enabled", async () => {
+                    RuntimeConfig.getInstance.returns({
+                        keepBrowserMode: { enabled: true, onFail: false },
+                    });
+
+                    const browser = stubBrowser_({ sessionId: "100500" });
+                    BrowserAgent.prototype.getBrowser.resolves(browser);
+
+                    await runTest_({
+                        onRun: ({ workers }) => {
+                            workers.emit(`worker.${browser.sessionId}.freeBrowser`);
+                        },
+                    });
+
+                    assert.notCalled(BrowserAgent.prototype.freeBrowser);
+                });
+
+                it("should not release browser when --keep-browser-on-fail is enabled and test fails", async () => {
+                    RuntimeConfig.getInstance.returns({
+                        keepBrowserMode: { enabled: true, onFail: true },
+                    });
+
+                    const browser = stubBrowser_({ sessionId: "100500" });
+                    BrowserAgent.prototype.getBrowser.resolves(browser);
+
+                    const workers = mkWorkers_();
+                    workers.runTest.callsFake(() => {
+                        workers.emit(`worker.${browser.sessionId}.freeBrowser`, { isLastTestFailed: true });
+                        return Promise.reject(new Error("Test failed"));
+                    });
+
+                    await run_({ workers });
+
+                    assert.notCalled(BrowserAgent.prototype.freeBrowser);
+                });
+
+                it("should release browser when --keep-browser-on-fail is enabled and test passes", async () => {
+                    RuntimeConfig.getInstance.returns({
+                        keepBrowserMode: { enabled: true, onFail: true },
+                    });
+
+                    const browser = stubBrowser_({ sessionId: "100500" });
+                    BrowserAgent.prototype.getBrowser.resolves(browser);
+
+                    await runTest_({
+                        onRun: ({ workers }) => {
+                            workers.emit(`worker.${browser.sessionId}.freeBrowser`);
+                        },
+                    });
+
+                    assert.calledOnce(BrowserAgent.prototype.freeBrowser);
+                });
+
+                it("should release browser when keep-browser mode is disabled", async () => {
+                    RuntimeConfig.getInstance.returns({
+                        keepBrowserMode: { enabled: false, onFail: false },
+                    });
+
+                    const browser = stubBrowser_({ sessionId: "100500" });
+                    BrowserAgent.prototype.getBrowser.resolves(browser);
+
+                    await runTest_({
+                        onRun: ({ workers }) => {
+                            workers.emit(`worker.${browser.sessionId}.freeBrowser`);
+                        },
+                    });
+
+                    assert.calledOnce(BrowserAgent.prototype.freeBrowser);
+                });
             });
         });
     });

--- a/test/src/testplane.js
+++ b/test/src/testplane.js
@@ -216,6 +216,10 @@ describe("testplane", () => {
                 },
                 devtools: true,
                 local: false,
+                keepBrowserMode: {
+                    enabled: false,
+                    onFail: false,
+                },
             });
 
             assert.calledOnce(RuntimeConfig.getInstance);
@@ -226,6 +230,7 @@ describe("testplane", () => {
                 replMode: { enabled: true },
                 devtools: true,
                 local: false,
+                keepBrowserMode: { enabled: false, onFail: false },
             });
             assert.callOrder(RuntimeConfig.getInstance, NodejsEnvRunner.create);
         });
@@ -335,16 +340,24 @@ describe("testplane", () => {
                 const grep = "baz.*";
                 const sets = ["set1", "set2"];
                 const replMode = { enabled: false };
+                const keepBrowserMode = { enabled: false };
 
                 sandbox.spy(Testplane.prototype, "readTests");
 
-                await runTestplane(testPaths, { browsers, grep, sets, replMode });
+                await runTestplane(testPaths, {
+                    browsers,
+                    grep,
+                    sets,
+                    replMode,
+                    keepBrowserMode,
+                });
 
                 assert.calledOnceWith(Testplane.prototype.readTests, testPaths, {
                     browsers,
                     grep,
                     sets,
                     replMode,
+                    keepBrowserMode,
                 });
             });
 
@@ -652,6 +665,7 @@ describe("testplane", () => {
                 sets: ["s1", "s2"],
                 grep: "grep",
                 replMode: { enabled: false },
+                keepBrowserMode: { enabled: false, onFail: false },
                 runnableOpts: {
                     saveLocations: true,
                 },
@@ -664,6 +678,7 @@ describe("testplane", () => {
                 sets: ["s1", "s2"],
                 grep: "grep",
                 replMode: { enabled: false },
+                keepBrowserMode: { enabled: false, onFail: false },
                 runnableOpts: {
                     saveLocations: true,
                 },

--- a/test/src/worker/runner/test-runner/index.js
+++ b/test/src/worker/runner/test-runner/index.js
@@ -915,4 +915,22 @@ describe("worker/runner/test-runner", () => {
             });
         });
     });
+
+    describe("isLastTestFailed flag initialization", () => {
+        it("should automatically reset isLastTestFailed flag when creating browser", async () => {
+            const browser = mkBrowser_();
+            browser.state.isLastTestFailed = false;
+            BrowserAgent.prototype.getBrowser.resolves(browser);
+
+            const runner = mkRunner_();
+            await runner.prepareToRun({
+                sessionId: "session-id",
+                sessionCaps: {},
+                sessionOpts: {},
+                state: { isLastTestFailed: true },
+            });
+
+            assert.strictEqual(browser.state.isLastTestFailed, false);
+        });
+    });
 });


### PR DESCRIPTION
Add --keep-browser and --keep-browser-on-fail CLI flags
to keep browser sessions alive for debugging purposes.

Fixes #1096