### PR TITLE
chore: remove unused code

### DIFF
--- a/src/runner/browser-runner.ts
+++ b/src/runner/browser-runner.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events";
 import _ from "lodash";
-import { Runner } from "./runner";
+import { CancelableEmitter } from "./types";
 import * as TestRunner from "./test-runner";
 import { InterceptedEvent, MasterEvents } from "../events";
 import SuiteMonitor from "./suite-monitor";
@@ -10,13 +10,12 @@ import { Config } from "../config";
 import { BrowserPool } from "../browser-pool";
 import { Workers } from "./index";
 import type { Test } from "../types";
-import { TestCollection } from "../test-collection";
 
 export interface BrowserRunner {
     on(event: InterceptedEvent, handler: (test: Test) => void): this;
 }
 
-export class BrowserRunner extends Runner {
+export class BrowserRunner extends CancelableEmitter {
     private _browserId: string;
     private config: Config;
     private browserPool: BrowserPool;
@@ -39,14 +38,6 @@ export class BrowserRunner extends Runner {
 
     get browserId(): string {
         return this._browserId;
-    }
-
-    async run(testCollection: TestCollection): Promise<void> {
-        testCollection.eachTestByVersions(this._browserId, (test: Test) => {
-            this.running.add(this._runTest(test));
-        });
-
-        await this.running.done();
     }
 
     addTestToRun(test: Test): boolean {

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -11,7 +11,7 @@ import {
     Interceptor,
     InterceptData,
 } from "../events";
-import { Runner } from "./runner";
+import { RunnableEmitter } from "./types";
 import RuntimeConfig from "../config/runtime-config";
 import WorkersRegistry from "../utils/workers-registry";
 import PromiseGroup from "./promise-group";
@@ -36,7 +36,11 @@ type MapOfMethods<T extends ReadonlyArray<string>> = {
 
 type RegisterWorkers<T extends ReadonlyArray<string>> = EventEmitter & MapOfMethods<T>;
 
-export class MainRunner extends Runner {
+/**
+ * Part of Public API:
+ * @link https://testplane.io/docs/v8/reference/testplane-events/#runner_start
+ */
+export class MainRunner extends RunnableEmitter {
     protected config: Config;
     protected interceptors: Interceptor[];
     protected browserPool: pool.BrowserPool | null;
@@ -78,7 +82,7 @@ export class MainRunner extends Runner {
         }
 
         this.workersRegistry.init();
-        this.workers = this.workersRegistry.register(require.resolve("../worker"), ["runTest", "cancel"]) as Workers;
+        this.workers = this.registerWorkers(require.resolve("../worker"), ["runTest", "cancel"] as const) as Workers;
         this.browserPool = pool.create(this.config, this);
     }
 

--- a/src/runner/test-runner/insistant-test-runner.js
+++ b/src/runner/test-runner/insistant-test-runner.js
@@ -2,14 +2,14 @@
 
 const _ = require("lodash");
 
-const { Runner } = require("../runner");
+const { RunnableEmitter } = require("../types");
 const RegularTestRunner = require("./regular-test-runner");
 const HighPriorityBrowserAgent = require("./high-priority-browser-agent");
 const { MasterEvents } = require("../../events");
 const { passthroughEvent } = require("../../events/utils");
 const { NoRefImageError } = require("../../browser/commands/assert-view/errors/no-ref-image-error");
 
-module.exports = class InsistantTestRunner extends Runner {
+module.exports = class InsistantTestRunner extends RunnableEmitter {
     constructor(test, config, browserAgent) {
         super();
 

--- a/src/runner/test-runner/regular-test-runner.js
+++ b/src/runner/test-runner/regular-test-runner.js
@@ -2,12 +2,12 @@
 
 const crypto = require("crypto");
 const _ = require("lodash");
-const { Runner } = require("../runner");
+const { RunnableEmitter } = require("../types");
 const logger = require("../../utils/logger");
 const { MasterEvents } = require("../../events");
 const AssertViewResults = require("../../browser/commands/assert-view/assert-view-results");
 
-module.exports = class RegularTestRunner extends Runner {
+module.exports = class RegularTestRunner extends RunnableEmitter {
     constructor(test, browserAgent) {
         super();
 

--- a/src/runner/test-runner/skipped-test-runner.js
+++ b/src/runner/test-runner/skipped-test-runner.js
@@ -1,9 +1,9 @@
 "use strict";
 
-const { Runner } = require("../runner");
+const { RunnableEmitter } = require("../types");
 const { MasterEvents } = require("../../events");
 
-module.exports = class SkippedTestRunner extends Runner {
+module.exports = class SkippedTestRunner extends RunnableEmitter {
     constructor(test) {
         super();
 

--- a/src/runner/types.ts
+++ b/src/runner/types.ts
@@ -3,12 +3,14 @@ import { AsyncEmitter } from "../events";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Constructor<T = object> = new (...args: any[]) => T;
 
-export abstract class Runner extends AsyncEmitter {
+export abstract class CancelableEmitter extends AsyncEmitter {
     static create<T>(this: Constructor<T>, ...args: unknown[]): T {
         return new this(...args);
     }
 
-    abstract run(...args: unknown[]): Promise<void>;
-
     abstract cancel(): void;
+}
+
+export abstract class RunnableEmitter extends CancelableEmitter {
+    abstract run(...args: unknown[]): Promise<void>;
 }

--- a/src/worker/runner/test-runner/index.js
+++ b/src/worker/runner/test-runner/index.js
@@ -2,7 +2,6 @@
 "use strict";
 
 const _ = require("lodash");
-const { Runner } = require("./runner");
 const HookRunner = require("./hook-runner");
 const ExecutionThread = require("./execution-thread");
 const OneTimeScreenshooter = require("./one-time-screenshooter");
@@ -13,14 +12,12 @@ const { filterExtraStackFrames } = require("../../../browser/stacktrace/utils");
 const { extendWithCodeSnippet } = require("../../../error-snippets");
 const { TestplaneInternalError } = require("../../../errors");
 
-module.exports = class TestRunner extends Runner {
+module.exports = class TestRunner {
     static create(...args) {
         return new this(...args);
     }
 
     constructor({ test, file, config, browserAgent, attempt }) {
-        super();
-
         this._test = test.clone();
         this._test.testplaneCtx = _.cloneDeep(test.testplaneCtx) || {};
 

--- a/src/worker/runner/test-runner/runner.ts
+++ b/src/worker/runner/test-runner/runner.ts
@@ -1,9 +1,0 @@
-import { Constructor } from "type-fest";
-
-export abstract class Runner {
-    static create<T>(this: Constructor<T>, ...args: unknown[]): T {
-        return new this(...args);
-    }
-
-    abstract run(...args: unknown[]): Promise<void>;
-}

--- a/test/src/runner/browser-runner.js
+++ b/test/src/runner/browser-runner.js
@@ -39,15 +39,17 @@ describe("runner/browser-runner", () => {
         const specs = { defaultBro: [] };
         const testCollection = opts.testCollection || TestCollection.create(specs, config);
 
-        return runner.run(testCollection);
+        testCollection.eachTest(test => runner.addTestToRun(test));
+
+        return runner.waitTestsCompletion();
     };
 
     const stubTestCollection_ = (tests = [], browserVersion = "1.0") => {
-        TestCollection.prototype.eachTestByVersions.callsFake((browserId, cb) =>
+        TestCollection.prototype.eachTest.callsFake(cb =>
             tests.forEach(test => {
                 test.browserVersion = browserVersion;
 
-                cb(test, browserId, browserVersion);
+                cb(test);
             }),
         );
     };
@@ -57,7 +59,7 @@ describe("runner/browser-runner", () => {
         sandbox.stub(TestRunner.prototype, "run").resolves();
         sandbox.stub(TestRunner.prototype, "cancel");
 
-        sandbox.stub(TestCollection.prototype, "eachTestByVersions");
+        sandbox.stub(TestCollection.prototype, "eachTest");
 
         sandbox.spy(SuiteMonitor, "create");
         sandbox.stub(SuiteMonitor.prototype, "testBegin");
@@ -128,7 +130,6 @@ describe("runner/browser-runner", () => {
 
             await run_({ runner });
 
-            assert.calledTwice(TestRunner.prototype.run);
             assert.calledOnce(addedTestRunner);
         });
     });
@@ -148,136 +149,6 @@ describe("runner/browser-runner", () => {
             await runner.waitTestsCompletion().then(afterWait);
 
             assert.callOrder(afterFirstTest, afterSecondTest, afterWait);
-        });
-    });
-
-    describe("run", () => {
-        it("should process only tests for specified browser", async () => {
-            const runner = mkRunner_({ browserId: "bro" });
-
-            await run_({ runner });
-
-            assert.calledOnceWith(TestCollection.prototype.eachTestByVersions, "bro");
-        });
-
-        it("should create browser agent for each test in collection", async () => {
-            const test1 = Test.create({ title: "foo" });
-            const test2 = Test.create({ title: "bar" });
-
-            stubTestCollection_([test1, test2], "1.0");
-
-            const pool = BrowserPool.create(makeConfigStub());
-            const runner = mkRunner_({ browserId: "bro", browserPool: pool });
-
-            await run_({ runner });
-
-            assert.calledTwice(BrowserAgent.create);
-            assert.calledWith(BrowserAgent.create.firstCall, { id: "bro", version: "1.0", pool });
-            assert.calledWith(BrowserAgent.create.secondCall, { id: "bro", version: "1.0", pool });
-        });
-
-        it("should create test runner for each test in collection", async () => {
-            const test1 = Test.create({ title: "foo" });
-            const test2 = Test.create({ title: "bar" });
-
-            stubTestCollection_([test1, test2]);
-
-            await run_();
-
-            assert.calledTwice(TestRunnerFabric.create);
-            assert.calledWith(TestRunnerFabric.create, test1);
-            assert.calledWith(TestRunnerFabric.create, test2);
-        });
-
-        it("should pass config and browser agent to test runner", async () => {
-            const config = makeConfigStub();
-            const browserAgent = BrowserAgent.create();
-            BrowserAgent.create.returns(browserAgent);
-
-            const runner = mkRunner_({ config });
-
-            await run_({ runner });
-
-            assert.calledOnceWith(TestRunnerFabric.create, sinon.match.any, config, browserAgent);
-        });
-
-        it("should wait for all test runners", async () => {
-            stubTestCollection_([Test.create({ title: "foo" }), Test.create({ title: "bar" })]);
-            const afterFirstTest = sinon.stub().named("afterFirstTest");
-            const afterSecondTest = sinon.stub().named("afterSecondTest");
-            const afterRun = sinon.stub().named("afterRun");
-
-            TestRunner.prototype.run.onFirstCall().callsFake(() => promiseDelay(1).then(afterFirstTest));
-            TestRunner.prototype.run.onSecondCall().callsFake(() => promiseDelay(10).then(afterSecondTest));
-
-            await run_();
-            afterRun();
-
-            assert.callOrder(afterFirstTest, afterSecondTest, afterRun);
-        });
-
-        ["TEST_BEGIN", "TEST_END", "TEST_PASS", "TEST_FAIL", "TEST_PENDING", "RETRY"].forEach(event => {
-            it(`should passthrough ${event} from test runner`, async () => {
-                TestRunner.prototype.run.callsFake(function () {
-                    this.emit(Events[event], { foo: "bar" });
-                    return Promise.resolve();
-                });
-
-                const onEvent = sinon.stub().named(`on${event}`);
-                const runner = mkRunner_({ browserId: "bro" }).on(Events[event], onEvent);
-
-                await run_({ runner });
-
-                assert.calledOnceWith(onEvent, { foo: "bar", browserId: "bro" });
-            });
-        });
-
-        it("should passthrough SUITE_BEGIN from suite monitor before TEST_BEGIN from test runner", async () => {
-            const onTestBegin = sinon.stub().named("onTestBegin");
-            const onSuiteBegin = sinon.stub().named("onSuiteBegin");
-
-            SuiteMonitor.prototype.testBegin.callsFake(function () {
-                this.emit(Events.SUITE_BEGIN);
-            });
-            TestRunner.prototype.run.callsFake(function () {
-                this.emit(Events.TEST_BEGIN);
-                return Promise.resolve();
-            });
-
-            const runner = mkRunner_().on(Events.TEST_BEGIN, onTestBegin).on(Events.SUITE_BEGIN, onSuiteBegin);
-
-            await run_({ runner });
-
-            assert.callOrder(onSuiteBegin, onTestBegin);
-        });
-
-        it("should passthrough SUITE_END from suite monitor after TEST_END from test runner", async () => {
-            const onTestEnd = sinon.stub().named("onTestEnd");
-            const onSuiteEnd = sinon.stub().named("onSuiteEnd");
-
-            SuiteMonitor.prototype.testEnd.callsFake(function () {
-                this.emit(Events.SUITE_END);
-            });
-            TestRunner.prototype.run.callsFake(function () {
-                this.emit(Events.TEST_END);
-                return Promise.resolve();
-            });
-
-            const runner = mkRunner_().on(Events.TEST_END, onTestEnd).on(Events.SUITE_END, onSuiteEnd);
-
-            await run_({ runner });
-
-            assert.callOrder(onTestEnd, onSuiteEnd);
-        });
-
-        it("should subscribe suite monitor to RETRY event", async () => {
-            TestRunner.prototype.run.callsFake(function () {
-                this.emit(Events.RETRY, { foo: "bar" });
-            });
-
-            await run_();
-
-            assert.calledOnceWith(SuiteMonitor.prototype.testRetry, sinon.match({ foo: "bar" }));
         });
     });
 

--- a/test/src/runner/browser-runner.js
+++ b/test/src/runner/browser-runner.js
@@ -130,6 +130,7 @@ describe("runner/browser-runner", () => {
 
             await run_({ runner });
 
+            assert.calledTwice(TestRunner.prototype.run);
             assert.calledOnce(addedTestRunner);
         });
     });


### PR DESCRIPTION
We had:
- "Runner" pure abstract class at "runner/runner.ts" 
- "Runner" pure abstract class at "worker/runner/test-runner/runner.ts"
- "Runner" class at "worker/runner/index.js"

Now we only have one "Runner"