### PR TITLE
feat: implement type-safe isomorphic coords helpers

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
     testplane-e2e:
-        runs-on: self-hosted-arc
+        runs-on: ubuntu-latest
 
         permissions:
             contents: write

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
     build:
-        runs-on: self-hosted-arc
+        runs-on: ubuntu-latest
 
         strategy:
             matrix:

--- a/.github/workflows/standalone-e2e.yml
+++ b/.github/workflows/standalone-e2e.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     integration-test:
-        runs-on: self-hosted-arc
+        runs-on: ubuntu-latest
         strategy:
             matrix:
                 node-version: [20.18.1]

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test-integration": "npm run create-client-scripts-symlinks && mocha -r ts-node/register -r test/integration/*/**",
     "test-e2e": "npm run test-e2e:generate-fixtures && npm run test-e2e:run-tests",
     "test-e2e:run-tests": "node bin/testplane --config test/e2e/testplane.config.ts",
-    "test-e2e:generate-fixtures": "node bin/testplane --config test/e2e/fixtures/basic-report/testplane.config.ts",
+    "test-e2e:generate-fixtures": "node bin/testplane --config test/e2e/fixtures/basic-report/testplane.config.ts || true",
     "test-e2e:gui": "node bin/testplane --config test/e2e/testplane.config.ts gui",
     "toc": "doctoc docs --title '### Contents'",
     "precommit": "npm run lint",

--- a/src/browser/isomorphic/assign.ts
+++ b/src/browser/isomorphic/assign.ts
@@ -1,0 +1,15 @@
+/** ES5-safe Object.assign polyfill for use in browser bundles targeting old browsers */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function assign<T>(target: T, ...sources: any[]): T {
+    for (let i = 0; i < sources.length; i++) {
+        const source = sources[i];
+
+        for (const key in source) {
+            if (Object.prototype.hasOwnProperty.call(source, key)) {
+                (target as Record<string, unknown>)[key] = (source as Record<string, unknown>)[key];
+            }
+        }
+    }
+
+    return target;
+}

--- a/src/browser/isomorphic/geometry.ts
+++ b/src/browser/isomorphic/geometry.ts
@@ -1,0 +1,273 @@
+import { assign } from "./assign";
+
+declare const brand: unique symbol;
+type Brand<T, B extends string> = T & { readonly [brand]: B };
+
+export type Space = "page" | "viewport" | "image" | "capture";
+/** css are logical pixels, device are physical pixels, usually equal to <logical pixels> * <device pixel ratio> */
+export type Unit = "css" | "device";
+type MainAxis = "x" | "y";
+type InverseAxis = "x-inverse" | "y-inverse";
+type Axis = MainAxis | InverseAxis;
+
+export type Coord<S extends Space, U extends Unit, A extends Axis> = Brand<number, `${S}:${U}:${A}`>;
+export type Length<U extends Unit, A extends MainAxis> = Brand<number, `${U}:${A}:len`>;
+
+export type Point<S extends Space, U extends Unit> = Readonly<{
+    top: Coord<S, U, "y">;
+    left: Coord<S, U, "x">;
+}>;
+
+export type Size<U extends Unit> = Readonly<{
+    width: Length<U, "x">;
+    height: Length<U, "y">;
+}>;
+
+export type Rect<S extends Space, U extends Unit> = Point<S, U> & Size<U>;
+
+export type YBand<S extends Space, U extends Unit> = {
+    top: Coord<S, U, "y">;
+    height: Length<U, "y">;
+};
+
+export type XBand<S extends Space, U extends Unit> = {
+    left: Coord<S, U, "x">;
+    width: Length<U, "x">;
+};
+
+export const getSize = <U extends Unit>(rect: Rect<Space, U>): Size<U> => {
+    return {
+        width: rect.width,
+        height: rect.height,
+    };
+};
+
+export const addCoords = <T extends Coord<Space, Unit, Axis>>(a: T, b: T): T => {
+    return (a + b) as T;
+};
+
+export const subtractCoords = <T extends Coord<Space, Unit, Axis>>(a: T, b: T): T => {
+    return (a - b) as T;
+};
+
+export const equalsSize = <T extends Size<Unit>>(a: T, b: T): boolean => {
+    return a.width === b.width && a.height === b.height;
+};
+
+export const prettySize = <T extends Size<Unit>>(size: T): string => {
+    return `${size.width} x ${size.height} (width x height)`;
+};
+
+export const intersectYBands = <T extends YBand<Space, Unit>>(a: T | null, b: T | null): T | null => {
+    if (!a || !b) {
+        return null;
+    }
+    const top = Math.max(a.top, b.top);
+    const bottom = Math.min(a.top + a.height, b.top + b.height);
+
+    return bottom <= top ? null : ({ top, height: bottom - top } as T);
+};
+
+export const intersectXBands = <T extends XBand<Space, Unit>>(a: T | null, b: T | null): T | null => {
+    if (!a || !b) {
+        return null;
+    }
+    const left = Math.max(a.left, b.left);
+    const right = Math.min(a.left + a.width, b.left + b.width);
+
+    return right <= left ? null : ({ left, width: right - left } as T);
+};
+
+export const getIntersection = <
+    S extends Space,
+    U extends Unit,
+    A extends Rect<S, U> | YBand<S, U> | XBand<S, U>,
+    B extends Rect<S, U> | YBand<S, U> | XBand<S, U>,
+>(
+    a: A | null,
+    b: B | null,
+): (A & B) | null => {
+    if (!a || !b) return null;
+
+    const result = { ...a, ...b };
+
+    if ("top" in a && "top" in b) {
+        const y = intersectYBands(a as YBand<S, U>, b as YBand<S, U>);
+        if (!y) return null;
+        assign(result, y);
+    }
+
+    if ("left" in a && "left" in b) {
+        const x = intersectXBands(a as XBand<S, U>, b as XBand<S, U>);
+        if (!x) return null;
+        assign(result, x);
+    }
+
+    return result as A & B;
+};
+
+type GetUnit<T> = T extends Coord<Space, infer Unit, Axis> ? Unit : never;
+type GetAxis<T> = T extends Coord<Space, Unit, infer Axis> ? Axis : never;
+
+export const getHeight = <T extends Coord<Space, Unit, "y">>(a: T, b: T): Length<GetUnit<T>, GetAxis<T>> => {
+    return Math.abs(a - b) as Length<GetUnit<T>, GetAxis<T>>;
+};
+
+export const getWidth = <T extends Coord<Space, Unit, "x">>(a: T, b: T): Length<GetUnit<T>, GetAxis<T>> => {
+    return Math.abs(a - b) as Length<GetUnit<T>, GetAxis<T>>;
+};
+
+export const getBottom = <S extends Space, U extends Unit>(bandOrRect: YBand<S, U>): Coord<S, U, "y"> => {
+    return (bandOrRect.top + bandOrRect.height) as Coord<S, U, "y">;
+};
+
+export const getRight = <S extends Space, U extends Unit>(bandOrRect: XBand<S, U>): Coord<S, U, "x"> => {
+    return (bandOrRect.left + bandOrRect.width) as Coord<S, U, "x">;
+};
+
+export const getMaxLength = <U extends Unit, A extends MainAxis>(...lengths: Length<U, A>[]): Length<U, A> => {
+    return Math.max(...lengths) as Length<U, A>;
+};
+
+export const getMaxCoord = <T extends Coord<Space, Unit, Axis>>(...coords: T[]): T => {
+    return Math.max(...coords) as T;
+};
+
+export const getMinCoord = <T extends Coord<Space, Unit, Axis>>(...coords: T[]): T => {
+    return Math.min(...coords) as T;
+};
+
+export const fromCaptureAreaToViewport = <U extends Unit>(
+    coordRelativeToCaptureArea: Coord<"capture", U, "y">,
+    captureAreaTopRelativeToViewport: Coord<"viewport", U, "y">,
+): Coord<"viewport", U, "y"> => {
+    return (coordRelativeToCaptureArea + captureAreaTopRelativeToViewport) as Coord<"viewport", U, "y">;
+};
+
+export const fromViewportToCaptureArea = <U extends Unit>(
+    coordRelativeToViewport: Coord<"viewport", U, "y">,
+    captureAreaTopRelativeToViewport: Coord<"viewport", U, "y">,
+): Coord<"capture", U, "y"> => {
+    return getHeight(coordRelativeToViewport, captureAreaTopRelativeToViewport) as number as Coord<"capture", U, "y">;
+};
+
+export const getCoveringRect = <T extends Rect<Space, Unit>>(rects: T[]): T => {
+    if (rects.length === 0) {
+        throw new Error("No rectangles to cover");
+    }
+
+    let left = rects[0].left;
+    let top = rects[0].top;
+    let right = getRight(rects[0]);
+    let bottom = getBottom(rects[0]);
+
+    for (let i = 1; i < rects.length; i++) {
+        const r = rects[i];
+        const rLeft = r.left;
+        const rTop = r.top;
+        left = getMinCoord(left, rLeft);
+        top = getMinCoord(top, rTop);
+        right = getMaxCoord(right, getRight(r));
+        bottom = getMaxCoord(bottom, getBottom(r));
+    }
+
+    return { left, top, width: getWidth(left, right), height: getHeight(top, bottom) } as T;
+};
+
+export const roundCoords = <T extends Rect<Space, Unit> | YBand<Space, Unit> | XBand<Space, Unit>>(value: T): T => {
+    const v = value as unknown as Record<string, number>;
+    const result: Record<string, number> = {};
+
+    if ("top" in v) {
+        const top = v.top;
+        result.top = Math.floor(top);
+        if ("height" in v) {
+            result.height = Math.ceil(top + v.height) - result.top;
+        }
+    }
+
+    if ("left" in v) {
+        const left = v.left;
+        result.left = Math.floor(left);
+        if ("width" in v) {
+            result.width = Math.ceil(left + v.width) - result.left;
+        }
+    }
+
+    return result as T;
+};
+
+type NumericShape = Rect<Space, Unit> | YBand<Space, Unit> | XBand<Space, Unit> | Size<Unit> | Point<Space, Unit>;
+
+export const floorCoords = <T extends NumericShape>(value: T): T => {
+    const v = value as unknown as Record<string, number>;
+    const result: Record<string, number> = {};
+
+    for (const key in v) {
+        result[key] = Math.floor(v[key]);
+    }
+
+    return result as T;
+};
+
+export const ceilCoords = <T extends NumericShape>(value: T): T => {
+    const v = value as unknown as Record<string, number>;
+    const result: Record<string, number> = {};
+
+    for (const key in v) {
+        result[key] = Math.ceil(v[key]);
+    }
+
+    return result as T;
+};
+
+type CssToDevice<T> = T extends Rect<infer S, "css">
+    ? Rect<S, "device">
+    : T extends YBand<infer S, "css">
+    ? YBand<S, "device">
+    : T extends XBand<infer S, "css">
+    ? XBand<S, "device">
+    : T extends Size<"css">
+    ? Size<"device">
+    : T extends Point<infer S, "css">
+    ? Point<S, "device">
+    : never;
+
+export const fromCssToDevice = <
+    T extends Size<"css"> | Point<Space, "css"> | Rect<Space, "css"> | YBand<Space, "css"> | XBand<Space, "css">,
+>(
+    value: T,
+    pixelRatio: number,
+): CssToDevice<T> => {
+    const v = value as unknown as Record<string, number>;
+    const scaled: Record<string, number> = {};
+
+    for (const key in v) {
+        scaled[key] = v[key] * pixelRatio;
+    }
+
+    return (pixelRatio % 1 === 0 ? scaled : roundCoords(scaled as Rect<Space, Unit>)) as unknown as CssToDevice<T>;
+};
+
+export const fromCssToDeviceNumber: {
+    <S extends Space, U extends Unit, A extends Axis>(value: Coord<S, U, A>, pixelRatio: number): Coord<S, "device", A>;
+    <U extends Unit, A extends MainAxis>(value: Length<U, A>, pixelRatio: number): Length<"device", A>;
+} = (value: number, pixelRatio: number): never => {
+    return (value * pixelRatio) as never;
+};
+
+export const fromDeviceToCssNumber: {
+    <S extends Space, U extends Unit, A extends Axis>(value: Coord<S, U, A>, pixelRatio: number): Coord<S, "css", A>;
+    <U extends Unit, A extends MainAxis>(value: Length<U, A>, pixelRatio: number): Length<"css", A>;
+} = (value: number, pixelRatio: number): never => {
+    return (value / pixelRatio) as never;
+};
+
+export const fromBcrToRect = (bcr: DOMRect): Rect<"viewport", "css"> => {
+    return {
+        left: bcr.left as Coord<"viewport", "css", "x">,
+        top: bcr.top as Coord<"viewport", "css", "y">,
+        width: bcr.width as Length<"css", "x">,
+        height: bcr.height as Length<"css", "y">,
+    };
+};

--- a/src/browser/isomorphic/geometry.ts
+++ b/src/browser/isomorphic/geometry.ts
@@ -148,7 +148,7 @@ export const fromViewportToCaptureArea = <U extends Unit>(
     coordRelativeToViewport: Coord<"viewport", U, "y">,
     captureAreaTopRelativeToViewport: Coord<"viewport", U, "y">,
 ): Coord<"capture", U, "y"> => {
-    return getHeight(coordRelativeToViewport, captureAreaTopRelativeToViewport) as number as Coord<"capture", U, "y">;
+    return (coordRelativeToViewport - captureAreaTopRelativeToViewport) as Coord<"capture", U, "y">;
 };
 
 export const getCoveringRect = <T extends Rect<Space, Unit>>(rects: T[]): T => {
@@ -174,30 +174,32 @@ export const getCoveringRect = <T extends Rect<Space, Unit>>(rects: T[]): T => {
     return { left, top, width: getWidth(left, right), height: getHeight(top, bottom) } as T;
 };
 
-export const roundCoords = <T extends Rect<Space, Unit> | YBand<Space, Unit> | XBand<Space, Unit>>(value: T): T => {
+type NumericShape = Rect<Space, Unit> | YBand<Space, Unit> | XBand<Space, Unit> | Size<Unit> | Point<Space, Unit>;
+
+export const roundCoords = <T extends NumericShape>(value: T): T => {
     const v = value as unknown as Record<string, number>;
     const result: Record<string, number> = {};
 
     if ("top" in v) {
         const top = v.top;
         result.top = Math.floor(top);
-        if ("height" in v) {
-            result.height = Math.ceil(top + v.height) - result.top;
-        }
+    }
+
+    if ("height" in v) {
+        result.height = "top" in v ? Math.ceil(v.top + v.height) - result.top : Math.ceil(v.height);
     }
 
     if ("left" in v) {
         const left = v.left;
         result.left = Math.floor(left);
-        if ("width" in v) {
-            result.width = Math.ceil(left + v.width) - result.left;
-        }
+    }
+
+    if ("width" in v) {
+        result.width = "left" in v ? Math.ceil(v.left + v.width) - result.left : Math.ceil(v.width);
     }
 
     return result as T;
 };
-
-type NumericShape = Rect<Space, Unit> | YBand<Space, Unit> | XBand<Space, Unit> | Size<Unit> | Point<Space, Unit>;
 
 export const floorCoords = <T extends NumericShape>(value: T): T => {
     const v = value as unknown as Record<string, number>;
@@ -246,7 +248,7 @@ export const fromCssToDevice = <
         scaled[key] = v[key] * pixelRatio;
     }
 
-    return (pixelRatio % 1 === 0 ? scaled : roundCoords(scaled as Rect<Space, Unit>)) as unknown as CssToDevice<T>;
+    return (pixelRatio % 1 === 0 ? scaled : roundCoords(scaled as NumericShape)) as unknown as CssToDevice<T>;
 };
 
 export const fromCssToDeviceNumber: {

--- a/src/browser/isomorphic/index.ts
+++ b/src/browser/isomorphic/index.ts
@@ -1,0 +1,3 @@
+export * from "./assign";
+
+export * from "./geometry";

--- a/test/src/browser/isomorphic/geometry.ts
+++ b/test/src/browser/isomorphic/geometry.ts
@@ -1,0 +1,411 @@
+import {
+    addCoords,
+    ceilCoords,
+    equalsSize,
+    floorCoords,
+    fromBcrToRect,
+    fromCaptureAreaToViewport,
+    fromCssToDevice,
+    fromCssToDeviceNumber,
+    fromDeviceToCssNumber,
+    fromViewportToCaptureArea,
+    getBottom,
+    getCoveringRect,
+    getHeight,
+    getIntersection,
+    getMaxCoord,
+    getMaxLength,
+    getMinCoord,
+    getRight,
+    getSize,
+    getWidth,
+    intersectXBands,
+    intersectYBands,
+    prettySize,
+    roundCoords,
+    subtractCoords,
+} from "src/browser/isomorphic/geometry";
+import type { Coord, Length, Point, Rect, Size, XBand, YBand } from "src/browser/isomorphic/geometry";
+
+describe("browser/isomorphic/geometry", () => {
+    describe("getSize", () => {
+        it("should return width and height from rect", () => {
+            const rect = {
+                left: 1 as Coord<"page", "css", "x">,
+                top: 2 as Coord<"page", "css", "y">,
+                width: 30 as Length<"css", "x">,
+                height: 40 as Length<"css", "y">,
+            } as Rect<"page", "css">;
+
+            assert.deepEqual(getSize(rect), { width: 30, height: 40 });
+        });
+    });
+
+    describe("addCoords", () => {
+        it("should add coords of the same type", () => {
+            const a = 10 as Coord<"viewport", "css", "y">;
+            const b = -3 as Coord<"viewport", "css", "y">;
+
+            assert.equal(addCoords(a, b), 7);
+        });
+    });
+
+    describe("subtractCoords", () => {
+        it("should subtract coords of the same type", () => {
+            const a = 10 as Coord<"viewport", "device", "x">;
+            const b = 4 as Coord<"viewport", "device", "x">;
+
+            assert.equal(subtractCoords(a, b), 6);
+        });
+    });
+
+    describe("equalsSize", () => {
+        it("should compare size values", () => {
+            const base = { width: 100 as Length<"css", "x">, height: 50 as Length<"css", "y"> } as Size<"css">;
+            const same = { width: 100 as Length<"css", "x">, height: 50 as Length<"css", "y"> } as Size<"css">;
+            const other = { width: 100 as Length<"css", "x">, height: 51 as Length<"css", "y"> } as Size<"css">;
+
+            assert.isTrue(equalsSize(base, same));
+            assert.isFalse(equalsSize(base, other));
+        });
+    });
+
+    describe("prettySize", () => {
+        it("should format size as text", () => {
+            const size = { width: 10 as Length<"device", "x">, height: 20 as Length<"device", "y"> } as Size<"device">;
+
+            assert.equal(prettySize(size), "10 x 20 (width x height)");
+        });
+    });
+
+    describe("intersectYBands", () => {
+        it("should return overlapping part of y-bands", () => {
+            const a = { top: 10 as Coord<"viewport", "css", "y">, height: 20 as Length<"css", "y"> } as YBand<
+                "viewport",
+                "css"
+            >;
+            const b = { top: 25 as Coord<"viewport", "css", "y">, height: 20 as Length<"css", "y"> } as YBand<
+                "viewport",
+                "css"
+            >;
+
+            assert.deepEqual(intersectYBands(a, b), { top: 25, height: 5 });
+        });
+
+        it("should return null when there is no overlap", () => {
+            const a = { top: 10 as Coord<"viewport", "css", "y">, height: 20 as Length<"css", "y"> } as YBand<
+                "viewport",
+                "css"
+            >;
+            const b = { top: 30 as Coord<"viewport", "css", "y">, height: 10 as Length<"css", "y"> } as YBand<
+                "viewport",
+                "css"
+            >;
+
+            assert.isNull(intersectYBands(a, b));
+            assert.isNull(intersectYBands(a, null));
+        });
+    });
+
+    describe("intersectXBands", () => {
+        it("should return overlapping part of x-bands", () => {
+            const a = { left: 10 as Coord<"viewport", "device", "x">, width: 20 as Length<"device", "x"> } as XBand<
+                "viewport",
+                "device"
+            >;
+            const b = { left: 25 as Coord<"viewport", "device", "x">, width: 20 as Length<"device", "x"> } as XBand<
+                "viewport",
+                "device"
+            >;
+
+            assert.deepEqual(intersectXBands(a, b), { left: 25, width: 5 });
+        });
+
+        it("should return null when there is no overlap", () => {
+            const a = { left: 10 as Coord<"viewport", "device", "x">, width: 20 as Length<"device", "x"> } as XBand<
+                "viewport",
+                "device"
+            >;
+            const b = { left: 30 as Coord<"viewport", "device", "x">, width: 10 as Length<"device", "x"> } as XBand<
+                "viewport",
+                "device"
+            >;
+
+            assert.isNull(intersectXBands(a, b));
+            assert.isNull(intersectXBands(a, null));
+        });
+    });
+
+    describe("getIntersection", () => {
+        it("should intersect two rects", () => {
+            const a = {
+                left: 0 as Coord<"viewport", "device", "x">,
+                top: 0 as Coord<"viewport", "device", "y">,
+                width: 10 as Length<"device", "x">,
+                height: 10 as Length<"device", "y">,
+            } as Rect<"viewport", "device">;
+            const b = {
+                left: 5 as Coord<"viewport", "device", "x">,
+                top: 4 as Coord<"viewport", "device", "y">,
+                width: 10 as Length<"device", "x">,
+                height: 10 as Length<"device", "y">,
+            } as Rect<"viewport", "device">;
+
+            assert.deepEqual(getIntersection(a, b), { left: 5, top: 4, width: 5, height: 6 });
+        });
+
+        it("should return null when inputs do not intersect or are null", () => {
+            const a = {
+                left: 0 as Coord<"viewport", "device", "x">,
+                top: 0 as Coord<"viewport", "device", "y">,
+                width: 10 as Length<"device", "x">,
+                height: 10 as Length<"device", "y">,
+            } as Rect<"viewport", "device">;
+            const b = {
+                left: 20 as Coord<"viewport", "device", "x">,
+                top: 20 as Coord<"viewport", "device", "y">,
+                width: 10 as Length<"device", "x">,
+                height: 10 as Length<"device", "y">,
+            } as Rect<"viewport", "device">;
+
+            assert.isNull(getIntersection(a, b));
+            assert.isNull(getIntersection(a, null));
+        });
+    });
+
+    describe("getHeight", () => {
+        it("should return absolute difference between y coords", () => {
+            const a = 12 as Coord<"page", "css", "y">;
+            const b = 5 as Coord<"page", "css", "y">;
+
+            assert.equal(getHeight(a, b), 7);
+        });
+    });
+
+    describe("getWidth", () => {
+        it("should return absolute difference between x coords", () => {
+            const a = 12 as Coord<"page", "device", "x">;
+            const b = 5 as Coord<"page", "device", "x">;
+
+            assert.equal(getWidth(a, b), 7);
+        });
+    });
+
+    describe("getBottom", () => {
+        it("should return top plus height", () => {
+            const band = { top: 10 as Coord<"viewport", "css", "y">, height: 15 as Length<"css", "y"> } as YBand<
+                "viewport",
+                "css"
+            >;
+
+            assert.equal(getBottom(band), 25);
+        });
+    });
+
+    describe("getRight", () => {
+        it("should return left plus width", () => {
+            const band = { left: 10 as Coord<"viewport", "device", "x">, width: 15 as Length<"device", "x"> } as XBand<
+                "viewport",
+                "device"
+            >;
+
+            assert.equal(getRight(band), 25);
+        });
+    });
+
+    describe("getMaxLength", () => {
+        it("should return max length", () => {
+            const a = 5 as Length<"css", "y">;
+            const b = 10 as Length<"css", "y">;
+            const c = 3 as Length<"css", "y">;
+
+            assert.equal(getMaxLength(a, b, c), 10);
+        });
+    });
+
+    describe("getMaxCoord", () => {
+        it("should return max coord", () => {
+            const a = 5 as Coord<"viewport", "css", "x">;
+            const b = 10 as Coord<"viewport", "css", "x">;
+            const c = 3 as Coord<"viewport", "css", "x">;
+
+            assert.equal(getMaxCoord(a, b, c), 10);
+        });
+    });
+
+    describe("getMinCoord", () => {
+        it("should return min coord", () => {
+            const a = 5 as Coord<"viewport", "css", "x">;
+            const b = 10 as Coord<"viewport", "css", "x">;
+            const c = 3 as Coord<"viewport", "css", "x">;
+
+            assert.equal(getMinCoord(a, b, c), 3);
+        });
+    });
+
+    describe("fromCaptureAreaToViewport", () => {
+        it("should convert capture-area coord to viewport coord", () => {
+            const relative = 30 as Coord<"capture", "device", "y">;
+            const captureTop = 100 as Coord<"viewport", "device", "y">;
+
+            assert.equal(fromCaptureAreaToViewport(relative, captureTop), 130);
+        });
+    });
+
+    describe("fromViewportToCaptureArea", () => {
+        it("should convert viewport coord to capture-area coord", () => {
+            const viewportCoord = 130 as Coord<"viewport", "device", "y">;
+            const captureTop = 100 as Coord<"viewport", "device", "y">;
+
+            assert.equal(fromViewportToCaptureArea(viewportCoord, captureTop), 30);
+        });
+    });
+
+    describe("getCoveringRect", () => {
+        it("should return the smallest rect covering all rects", () => {
+            const a = {
+                left: 10 as Coord<"viewport", "device", "x">,
+                top: 20 as Coord<"viewport", "device", "y">,
+                width: 30 as Length<"device", "x">,
+                height: 40 as Length<"device", "y">,
+            } as Rect<"viewport", "device">;
+            const b = {
+                left: 5 as Coord<"viewport", "device", "x">,
+                top: 30 as Coord<"viewport", "device", "y">,
+                width: 10 as Length<"device", "x">,
+                height: 10 as Length<"device", "y">,
+            } as Rect<"viewport", "device">;
+
+            assert.deepEqual(getCoveringRect([a, b]), { left: 5, top: 20, width: 35, height: 40 });
+        });
+
+        it("should throw for empty rect list", () => {
+            assert.throws(() => getCoveringRect([] as Rect<"viewport", "device">[]), /No rectangles to cover/);
+        });
+    });
+
+    describe("roundCoords", () => {
+        it("should floor start coords and ceil end coords", () => {
+            const rect = {
+                left: 5.6 as Coord<"viewport", "css", "x">,
+                top: 10.2 as Coord<"viewport", "css", "y">,
+                width: 1.1 as Length<"css", "x">,
+                height: 2.2 as Length<"css", "y">,
+            } as Rect<"viewport", "css">;
+
+            assert.deepEqual(roundCoords(rect), { left: 5, top: 10, width: 2, height: 3 });
+        });
+    });
+
+    describe("floorCoords", () => {
+        it("should floor all numeric fields", () => {
+            const point = { left: 5.8 as Coord<"page", "css", "x">, top: 10.2 as Coord<"page", "css", "y"> } as Point<
+                "page",
+                "css"
+            >;
+
+            assert.deepEqual(floorCoords(point), { left: 5, top: 10 });
+        });
+    });
+
+    describe("ceilCoords", () => {
+        it("should ceil all numeric fields", () => {
+            const size = { width: 10.1 as Length<"css", "x">, height: 5.01 as Length<"css", "y"> } as Size<"css">;
+
+            assert.deepEqual(ceilCoords(size), { width: 11, height: 6 });
+        });
+    });
+
+    describe("fromCssToDevice", () => {
+        it("should scale values without rounding for integer pixel ratio", () => {
+            const rect = {
+                left: 0.25 as Coord<"viewport", "css", "x">,
+                top: 0.5 as Coord<"viewport", "css", "y">,
+                width: 10.25 as Length<"css", "x">,
+                height: 20.5 as Length<"css", "y">,
+            } as Rect<"viewport", "css">;
+
+            assert.deepEqual(fromCssToDevice(rect, 2), { left: 0.5, top: 1, width: 20.5, height: 41 });
+        });
+
+        it("should scale and round rect values for fractional pixel ratio", () => {
+            const rect = {
+                left: 1 as Coord<"viewport", "css", "x">,
+                top: 2 as Coord<"viewport", "css", "y">,
+                width: 3 as Length<"css", "x">,
+                height: 4 as Length<"css", "y">,
+            } as Rect<"viewport", "css">;
+
+            assert.deepEqual(fromCssToDevice(rect, 1.5), { left: 1, top: 3, width: 5, height: 6 });
+        });
+    });
+
+    describe("fromCssToDeviceNumber", () => {
+        it("should scale coords and lengths", () => {
+            const top = 10 as Coord<"viewport", "css", "y">;
+            const width = 3 as Length<"css", "x">;
+
+            assert.equal(fromCssToDeviceNumber(top, 2), 20);
+            assert.equal(fromCssToDeviceNumber(width, 2), 6);
+        });
+    });
+
+    describe("fromDeviceToCssNumber", () => {
+        it("should downscale coords and lengths", () => {
+            const top = 20 as Coord<"viewport", "device", "y">;
+            const width = 6 as Length<"device", "x">;
+
+            assert.equal(fromDeviceToCssNumber(top, 2), 10);
+            assert.equal(fromDeviceToCssNumber(width, 2), 3);
+        });
+    });
+
+    describe("fromBcrToRect", () => {
+        it("should map DOMRect to a viewport css rect", () => {
+            const bcr = { left: 1, top: 2, width: 3, height: 4 } as DOMRect;
+
+            assert.deepEqual(fromBcrToRect(bcr), { left: 1, top: 2, width: 3, height: 4 });
+        });
+    });
+
+    // Compile-time checks. Kept skipped because they validate types, not runtime behavior.
+    describe("types", () => {
+        it.skip("should keep helper contracts type-safe", () => {
+            const viewportTopCss = 10 as Coord<"viewport", "css", "y">;
+            const viewportLeftCss = 5 as Coord<"viewport", "css", "x">;
+            const pageTopCss = 7 as Coord<"page", "css", "y">;
+            const captureTopCss = 2 as Coord<"capture", "css", "y">;
+            const viewportTopDevice = 20 as Coord<"viewport", "device", "y">;
+            const cssWidth = 3 as Length<"css", "x">;
+
+            const sum: Coord<"viewport", "css", "y"> = addCoords(viewportTopCss, viewportTopCss);
+            const diff: Coord<"viewport", "css", "y"> = subtractCoords(viewportTopCss, viewportTopCss);
+            const height: Length<"css", "y"> = getHeight(viewportTopCss, viewportTopCss);
+            const width: Length<"css", "x"> = getWidth(viewportLeftCss, viewportLeftCss);
+            const viewportTop = fromCaptureAreaToViewport(captureTopCss, viewportTopCss);
+            const captureTop = fromViewportToCaptureArea(viewportTopCss, viewportTopCss);
+            const deviceWidth = fromCssToDeviceNumber(cssWidth, 2);
+            const cssTop = fromDeviceToCssNumber(viewportTopDevice, 2);
+
+            void [sum, diff, height, width, viewportTop, captureTop, deviceWidth, cssTop];
+
+            // @ts-expect-error different axis
+            addCoords(viewportTopCss, viewportLeftCss);
+            // @ts-expect-error different space
+            subtractCoords(viewportTopCss, pageTopCss);
+            // @ts-expect-error getWidth expects x-coords
+            getWidth(viewportTopCss, viewportTopCss);
+            // @ts-expect-error getHeight expects y-coords
+            getHeight(viewportLeftCss, viewportLeftCss);
+            // @ts-expect-error first arg should be capture-space y-coord
+            fromCaptureAreaToViewport(viewportTopCss, viewportTopCss);
+            // @ts-expect-error first arg should be viewport-space y-coord
+            fromViewportToCaptureArea(captureTopCss, viewportTopCss);
+            // @ts-expect-error css length converts to device length
+            const wrongLength: Length<"css", "x"> = fromCssToDeviceNumber(cssWidth, 2);
+            // @ts-expect-error device coord converts to css coord
+            const wrongCoord: Coord<"viewport", "device", "y"> = fromDeviceToCssNumber(viewportTopDevice, 2);
+            void [wrongLength, wrongCoord];
+        });
+    });
+});

--- a/test/src/browser/isomorphic/geometry.ts
+++ b/test/src/browser/isomorphic/geometry.ts
@@ -259,6 +259,22 @@ describe("browser/isomorphic/geometry", () => {
 
             assert.equal(fromViewportToCaptureArea(viewportCoord, captureTop), 30);
         });
+
+        it("should preserve negative offsets above capture-area top", () => {
+            const viewportCoord = 70 as Coord<"viewport", "device", "y">;
+            const captureTop = 100 as Coord<"viewport", "device", "y">;
+
+            assert.equal(fromViewportToCaptureArea(viewportCoord, captureTop), -30);
+        });
+
+        it("should be inverse of fromCaptureAreaToViewport", () => {
+            const captureRelative = -15 as Coord<"capture", "device", "y">;
+            const captureTop = 100 as Coord<"viewport", "device", "y">;
+
+            const viewportCoord = fromCaptureAreaToViewport(captureRelative, captureTop);
+
+            assert.equal(fromViewportToCaptureArea(viewportCoord, captureTop), captureRelative);
+        });
     });
 
     describe("getCoveringRect", () => {


### PR DESCRIPTION
### What's done?

Implemented a type system for type-safe coords operations.

With these, it becomes much harder to confuse numbers from different spaces or units.

These helpers are broadly used in the upcoming PRs.

For example:

- You can't get intersection of rects with different pixelRatios
- You can't combine two coords, if one is relative to viewport and the other is relative to the whole page
- You can't get a sum of `left` and `top` values without explicit type casting