### PR TITLE
fix: make BrowserConfig typing deterministic

### DIFF
--- a/src/config/browser-config.ts
+++ b/src/config/browser-config.ts
@@ -3,8 +3,12 @@ import * as _ from "lodash";
 import type { Test } from "../types";
 import type { CommonConfig } from "./types";
 
+export interface BrowserConfig extends CommonConfig {
+    id: string;
+}
+
 export class BrowserConfig {
-    constructor(browserOptions: CommonConfig) {
+    constructor(browserOptions: CommonConfig & { id: string }) {
         _.extend(this, browserOptions);
     }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -480,9 +480,3 @@ export interface RuntimeConfig {
 declare module "." {
     export interface Config extends ConfigParsed {}
 }
-
-declare module "./browser-config" {
-    export interface BrowserConfig extends CommonConfig {
-        id: string;
-    }
-}


### PR DESCRIPTION
### Problem

BrowserConfig receives ~40 properties dynamically via `_.extend(this, browserOptions)` in the constructor. Since TypeScript cannot infer dynamically assigned properties, the type information was added through a `declare module "./browser-config"` augmentation at the bottom of types.ts.

This pattern is order-dependent: the augmentation is only applied if types.ts is loaded before browser-config.d.ts is used. TypeScript's language server and newer type checkers like **tsgo** (**TypeScript 7**) do not guarantee file loading order, which causes intermittent errors:

`Property 'id' does not exist on type 'BrowserConfig'`
`Property 'urlHttpTimeout' does not exist on type 'BrowserConfig'`

These errors appear non-deterministically — present in one run, gone in the next.