### PR TITLE
feat(selectivity): add ability to save incomplete dumps

### DIFF
--- a/src/browser/cdp/selectivity/hash-writer.ts
+++ b/src/browser/cdp/selectivity/hash-writer.ts
@@ -61,7 +61,7 @@ export class HashWriter {
         dependencies.modules?.forEach(dependency => this._addModuleDependency(dependency));
     }
 
-    async save(readExisting?: boolean): Promise<void> {
+    async save(): Promise<void> {
         const hasStaged = Boolean(
             this._stagedFileHashes.size || this._stagedModuleHashes.size || this._stagedPatternHashes.size,
         );
@@ -89,13 +89,7 @@ export class HashWriter {
             shallowSortObject(dest);
         };
 
-        const fileContents = readExisting
-            ? await readHashFileContents(this._selectivityHashesPath, this._compresion)
-            : {
-                  files: {},
-                  modules: {},
-                  patterns: {},
-              };
+        const fileContents = await readHashFileContents(this._selectivityHashesPath, this._compresion);
 
         await writeTo(this._stagedFileHashes, fileContents.files);
         await writeTo(this._stagedModuleHashes, fileContents.modules);

--- a/src/browser/cdp/selectivity/index.ts
+++ b/src/browser/cdp/selectivity/index.ts
@@ -12,7 +12,7 @@ import { getCollectedTestplaneJsDependencies, getCollectedTestplanePngDependenci
 import { getHashReader } from "./hash-reader";
 import type { Config } from "../../../config";
 import { MasterEvents } from "../../../events";
-import { selectivityShouldRead, selectivityShouldWrite } from "./modes";
+import { selectivityShouldWrite } from "./modes";
 import { debugSelectivity } from "./debug";
 import { getUsedDumpsTracker } from "./used-dumps-tracker";
 import { DebuggerEvents } from "../domains/debugger";
@@ -21,18 +21,22 @@ import { CDPSessionId } from "../types";
 type StopSelectivityFn = (test: Test, shouldWrite: boolean) => Promise<void>;
 
 /**
- * Called at the end of successfull testplane run
+ * Called at the end of testplane run
  * Not using "Promise.all" here because all hashes are already calculated and cached at the start
  */
-export const updateSelectivityHashes = async (config: Config): Promise<void> => {
+export const updateSelectivityHashes = async (config: Config, isRunFailed: boolean): Promise<void> => {
     const browserIds = config.getBrowserIds();
     const processedRoots = new Set();
 
     for (const browserId of browserIds) {
         const browserConfig = config.forBrowser(browserId);
-        const { enabled, testDependenciesPath, compression, disableSelectivityPatterns } = browserConfig.selectivity;
-        const shouldReadExistingHashes = selectivityShouldRead(enabled);
-        const rootKey = `${shouldReadExistingHashes}#${testDependenciesPath}#${compression}`;
+        const { enabled, testDependenciesPath, compression, disableSelectivityPatterns, saveIncompleteDumpOnFail } =
+            browserConfig.selectivity;
+        const rootKey = `${testDependenciesPath}#${compression}`;
+
+        if ((isRunFailed || browserConfig.lastFailed.only) && !saveIncompleteDumpOnFail) {
+            continue;
+        }
 
         if (!selectivityShouldWrite(enabled) || processedRoots.has(rootKey)) {
             continue;
@@ -50,7 +54,7 @@ export const updateSelectivityHashes = async (config: Config): Promise<void> => 
         }
 
         try {
-            await hashWriter.save(shouldReadExistingHashes);
+            await hashWriter.save();
         } catch (cause) {
             throw new Error("Selectivity: couldn't save test dependencies hash", { cause });
         }
@@ -59,16 +63,21 @@ export const updateSelectivityHashes = async (config: Config): Promise<void> => 
     }
 };
 
-export const clearUnusedSelectivityDumps = async (config: Config): Promise<void> => {
+/**
+ * Called at the end of testplane run
+ */
+export const clearUnusedSelectivityDumps = async (config: Config, isRunFailed: boolean): Promise<void> => {
     const usedDumpsTracker = getUsedDumpsTracker();
     const browserIds = config.getBrowserIds();
     const selectivityRoots: string[] = [];
 
     for (const browserId of browserIds) {
         const browserConfig = config.forBrowser(browserId);
-        const { enabled, testDependenciesPath } = browserConfig.selectivity;
+        const { enabled, testDependenciesPath, saveIncompleteDumpOnFail } = browserConfig.selectivity;
 
-        if (selectivityShouldWrite(enabled) && !selectivityRoots.includes(testDependenciesPath)) {
+        if ((isRunFailed && !saveIncompleteDumpOnFail) || browserConfig.lastFailed.only) {
+            continue;
+        } else if (selectivityShouldWrite(enabled) && !selectivityRoots.includes(testDependenciesPath)) {
             selectivityRoots.push(testDependenciesPath);
         }
     }

--- a/src/browser/cdp/selectivity/runner.ts
+++ b/src/browser/cdp/selectivity/runner.ts
@@ -22,6 +22,16 @@ const shouldDisableBrowserSelectivity = _.memoize(
             return true;
         }
 
+        if (config.lastFailed.only) {
+            if (!config.selectivity.saveIncompleteDumpOnFail) {
+                logger.warn(`Disabling selectivity for ${browserId}: lastFailedOnly mode is enabled`);
+            } else {
+                debugSelectivity(`Not skipping tests for ${browserId}: lastFailedOnly mode controls it`);
+            }
+
+            return true;
+        }
+
         if (!config.selectivity.disableSelectivityPatterns.length) {
             return false;
         }
@@ -65,9 +75,10 @@ const shouldDisableBrowserSelectivity = _.memoize(
     },
     config => {
         const { enabled, testDependenciesPath, compression, disableSelectivityPatterns } = config.selectivity;
+        const lastFailed = config.lastFailed.only;
 
         return selectivityShouldRead(enabled)
-            ? testDependenciesPath + "#" + compression + "#" + disableSelectivityPatterns.join("#")
+            ? lastFailed + "#" + testDependenciesPath + "#" + compression + "#" + disableSelectivityPatterns.join("#")
             : "";
     },
 );

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -132,6 +132,7 @@ module.exports = {
     timeTravel: TimeTravelMode.Off,
     selectivity: {
         enabled: false,
+        saveIncompleteDumpOnFail: false,
         sourceRoot: "",
         testDependenciesPath: ".testplane/selectivity",
         compression: "gz",

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -419,6 +419,7 @@ export interface CommonConfig {
 
     selectivity: {
         enabled: SelectivityModeValue;
+        saveIncompleteDumpOnFail: boolean;
         sourceRoot: string;
         testDependenciesPath: string;
         compression: SelectivityCompressionType;

--- a/src/test-reader/test-parser.ts
+++ b/src/test-reader/test-parser.ts
@@ -98,9 +98,7 @@ export class TestParser extends EventEmitter {
                     }
                 }
             } catch {
-                logger.warn(
-                    `Could not read failed tests data at ${config.lastFailed.input}. Running all tests instead`,
-                );
+                logger.warn(`Could not read failed tests data at ${config.lastFailed.input}.`);
             }
         }
     }

--- a/src/testplane.ts
+++ b/src/testplane.ts
@@ -206,10 +206,10 @@ export class Testplane extends BaseTestplane {
             { shouldDisableSelectivity },
         );
 
-        if (!shouldDisableSelectivity && !this.isFailed()) {
+        if (!shouldDisableSelectivity) {
             const [updateResult, clearResult] = await Promise.allSettled([
-                updateSelectivityHashes(this.config),
-                clearUnusedSelectivityDumps(this.config),
+                updateSelectivityHashes(this.config, this.isFailed()),
+                clearUnusedSelectivityDumps(this.config, this.isFailed()),
             ]);
 
             if (updateResult.status === "rejected") {

--- a/test/src/browser/cdp/selectivity/hash-writer.ts
+++ b/test/src/browser/cdp/selectivity/hash-writer.ts
@@ -214,24 +214,7 @@ describe("CDP/Selectivity/HashWriter", () => {
             });
         });
 
-        it("should not readHashFileContents when readExisting is false", async () => {
-            const writer = new HashWriter("/test/selectivity", "none");
-            const dependencies = {
-                css: ["src/styles.css"],
-                js: [],
-                modules: [],
-                png: [],
-            };
-
-            fileHashProviderMock.calculateForFile.withArgs("src/styles.css").resolves("css-hash");
-
-            writer.addTestDependencyHashes(dependencies);
-            await writer.save(false);
-
-            assert.notCalled(readHashFileContentsStub);
-        });
-
-        it("should merge staged hashes with existing file contents when readExisting is true", async () => {
+        it("should merge staged hashes with existing file contents", async () => {
             const existingContents = {
                 files: { "src/old.css": "old-hash" },
                 modules: { "node_modules/old-module": "old-module-hash" },
@@ -255,7 +238,7 @@ describe("CDP/Selectivity/HashWriter", () => {
                 .resolves("module-hash");
 
             writer.addTestDependencyHashes(dependencies);
-            await writer.save(true);
+            await writer.save();
 
             assert.calledWith(writeJsonWithCompression, "/test/selectivity/hashes.json", {
                 files: {

--- a/test/src/browser/cdp/selectivity/index.ts
+++ b/test/src/browser/cdp/selectivity/index.ts
@@ -39,6 +39,7 @@ describe("CDP/Selectivity", () => {
         config: {
             selectivity: {
                 enabled: SelectivityModeValue;
+                saveIncompleteDumpOnFail: false;
                 sourceRoot: string;
                 testDependenciesPath: string;
                 compression: "none";
@@ -122,6 +123,7 @@ describe("CDP/Selectivity", () => {
             config: {
                 selectivity: {
                     enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
                     sourceRoot: "/test/source-root",
                     testDependenciesPath: "/test/dependencies",
                     compression: "none",
@@ -442,8 +444,10 @@ describe("CDP/Selectivity", () => {
                 configMock.forBrowser
                     .withArgs("chrome")
                     .returns({
+                        lastFailed: { only: false },
                         selectivity: {
                             enabled: mode,
+                            saveIncompleteDumpOnFail: false,
                             testDependenciesPath: "/test/path",
                             compression: "none",
                             disableSelectivityPatterns: ["src/**/*.js"],
@@ -451,8 +455,10 @@ describe("CDP/Selectivity", () => {
                     })
                     .withArgs("firefox")
                     .returns({
+                        lastFailed: { only: false },
                         selectivity: {
                             enabled: SelectivityMode.Enabled,
+                            saveIncompleteDumpOnFail: false,
                             testDependenciesPath: "/test/path",
                             compression: "none",
                             disableSelectivityPatterns: ["src/**/*.js"],
@@ -461,7 +467,7 @@ describe("CDP/Selectivity", () => {
 
                 hashReaderMock.patternHasChanged.resolves(true);
 
-                await updateSelectivityHashes(configMock as any);
+                await updateSelectivityHashes(configMock as any, false);
 
                 assert.calledOnceWith(getHashReaderStub, "/test/path", "none"); // Only for firefox
                 assert.calledOnceWith(hashWriterMock.addPatternDependencyHash, "src/**/*.js");
@@ -472,8 +478,10 @@ describe("CDP/Selectivity", () => {
         it("should update hashes for changed patterns", async () => {
             configMock.getBrowserIds.returns(["chrome"]);
             configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
                 selectivity: {
                     enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
                     testDependenciesPath: "/test/path",
                     compression: "gz",
                     disableSelectivityPatterns: ["pattern1", "pattern2", "pattern3"],
@@ -488,7 +496,7 @@ describe("CDP/Selectivity", () => {
                 .withArgs("pattern3")
                 .resolves(true);
 
-            await updateSelectivityHashes(configMock as any);
+            await updateSelectivityHashes(configMock as any, false);
 
             assert.calledWith(getHashReaderStub, "/test/path", "gz");
             assert.calledWith(getHashWriterStub, "/test/path", "gz");
@@ -501,8 +509,10 @@ describe("CDP/Selectivity", () => {
         it("should not add hashes for unchanged patterns", async () => {
             configMock.getBrowserIds.returns(["chrome"]);
             configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
                 selectivity: {
                     enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
                     testDependenciesPath: "/test/path",
                     compression: "none",
                     disableSelectivityPatterns: ["pattern1", "pattern2"],
@@ -511,7 +521,7 @@ describe("CDP/Selectivity", () => {
 
             hashReaderMock.patternHasChanged.resolves(false);
 
-            await updateSelectivityHashes(configMock as any);
+            await updateSelectivityHashes(configMock as any, false);
 
             assert.notCalled(hashWriterMock.addPatternDependencyHash);
             assert.calledOnce(hashWriterMock.save); // Still saves even if no patterns changed
@@ -522,8 +532,10 @@ describe("CDP/Selectivity", () => {
             configMock.forBrowser
                 .withArgs("chrome")
                 .returns({
+                    lastFailed: { only: false },
                     selectivity: {
                         enabled: SelectivityMode.Enabled,
+                        saveIncompleteDumpOnFail: false,
                         testDependenciesPath: "/test/chrome",
                         compression: "none",
                         disableSelectivityPatterns: ["chrome-pattern"],
@@ -531,8 +543,10 @@ describe("CDP/Selectivity", () => {
                 })
                 .withArgs("firefox")
                 .returns({
+                    lastFailed: { only: false },
                     selectivity: {
                         enabled: SelectivityMode.Enabled,
+                        saveIncompleteDumpOnFail: false,
                         testDependenciesPath: "/test/firefox",
                         compression: "gz",
                         disableSelectivityPatterns: ["firefox-pattern"],
@@ -541,7 +555,7 @@ describe("CDP/Selectivity", () => {
 
             hashReaderMock.patternHasChanged.resolves(true);
 
-            await updateSelectivityHashes(configMock as any);
+            await updateSelectivityHashes(configMock as any, false);
 
             assert.calledTwice(getHashReaderStub);
             assert.calledWith(getHashReaderStub.firstCall, "/test/chrome", "none");
@@ -553,8 +567,10 @@ describe("CDP/Selectivity", () => {
         it("should update hashes for WriteOnly mode", async () => {
             configMock.getBrowserIds.returns(["chrome"]);
             configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
                 selectivity: {
                     enabled: SelectivityMode.WriteOnly,
+                    saveIncompleteDumpOnFail: false,
                     testDependenciesPath: "/test/path",
                     compression: "none",
                     disableSelectivityPatterns: ["src/**/*.js"],
@@ -563,9 +579,85 @@ describe("CDP/Selectivity", () => {
 
             hashReaderMock.patternHasChanged.resolves(true);
 
-            await updateSelectivityHashes(configMock as any);
+            await updateSelectivityHashes(configMock as any, false);
 
             assert.calledOnceWith(hashWriterMock.addPatternDependencyHash, "src/**/*.js");
+            assert.calledOnce(hashWriterMock.save);
+        });
+
+        it("should skip saving when run is failed and saveIncompleteDumpOnFail is false", async () => {
+            configMock.getBrowserIds.returns(["chrome"]);
+            configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
+                selectivity: {
+                    enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
+                    testDependenciesPath: "/test/path",
+                    compression: "none",
+                    disableSelectivityPatterns: [],
+                },
+            });
+
+            await updateSelectivityHashes(configMock as any, true);
+
+            assert.notCalled(getHashReaderStub);
+            assert.notCalled(getHashWriterStub);
+            assert.notCalled(hashWriterMock.save);
+        });
+
+        it("should save when run is failed and saveIncompleteDumpOnFail is true", async () => {
+            configMock.getBrowserIds.returns(["chrome"]);
+            configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
+                selectivity: {
+                    enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: true,
+                    testDependenciesPath: "/test/path",
+                    compression: "none",
+                    disableSelectivityPatterns: [],
+                },
+            });
+
+            await updateSelectivityHashes(configMock as any, true);
+
+            assert.calledOnce(hashWriterMock.save);
+        });
+
+        it("should skip saving when lastFailed.only is true and saveIncompleteDumpOnFail is false", async () => {
+            configMock.getBrowserIds.returns(["chrome"]);
+            configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: true },
+                selectivity: {
+                    enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
+                    testDependenciesPath: "/test/path",
+                    compression: "none",
+                    disableSelectivityPatterns: [],
+                },
+            });
+
+            await updateSelectivityHashes(configMock as any, false);
+
+            assert.notCalled(getHashReaderStub);
+            assert.notCalled(getHashWriterStub);
+            assert.notCalled(hashWriterMock.save);
+        });
+
+        it("should save when lastFailed.only is true and saveIncompleteDumpOnFail is true", async () => {
+            configMock.getBrowserIds.returns(["chrome"]);
+            configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: true },
+                selectivity: {
+                    enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: true,
+                    testDependenciesPath: "/test/path",
+                    compression: "none",
+                    disableSelectivityPatterns: [],
+                },
+            });
+
+            await updateSelectivityHashes(configMock as any, false);
+
             assert.calledOnce(hashWriterMock.save);
         });
     });
@@ -588,20 +680,24 @@ describe("CDP/Selectivity", () => {
             configMock.forBrowser
                 .withArgs("chrome")
                 .returns({
+                    lastFailed: { only: false },
                     selectivity: {
                         enabled: SelectivityMode.Disabled,
+                        saveIncompleteDumpOnFail: false,
                         testDependenciesPath: "/test/chrome",
                     },
                 })
                 .withArgs("firefox")
                 .returns({
+                    lastFailed: { only: false },
                     selectivity: {
                         enabled: SelectivityMode.Disabled,
+                        saveIncompleteDumpOnFail: false,
                         testDependenciesPath: "/test/firefox",
                     },
                 });
 
-            await clearUnusedSelectivityDumps(configMock as any);
+            await clearUnusedSelectivityDumps(configMock as any, false);
 
             assert.notCalled(usedDumpsTrackerMock.usedDumpsFor);
             assert.notCalled(getSelectivityTestsPathStub);
@@ -612,13 +708,15 @@ describe("CDP/Selectivity", () => {
         it("should skip browsers with selectivity in read-only mode", async () => {
             configMock.getBrowserIds.returns(["chrome"]);
             configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
                 selectivity: {
                     enabled: SelectivityMode.ReadOnly,
+                    saveIncompleteDumpOnFail: false,
                     testDependenciesPath: "/test/deps",
                 },
             });
 
-            await clearUnusedSelectivityDumps(configMock as any);
+            await clearUnusedSelectivityDumps(configMock as any, false);
 
             assert.notCalled(usedDumpsTrackerMock.usedDumpsFor);
             assert.notCalled(getSelectivityTestsPathStub);
@@ -628,15 +726,17 @@ describe("CDP/Selectivity", () => {
         it("should skip selectivity root when no dumps were used for it", async () => {
             configMock.getBrowserIds.returns(["chrome"]);
             configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
                 selectivity: {
                     enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
                     testDependenciesPath: "/test/deps",
                 },
             });
 
             usedDumpsTrackerMock.usedDumpsFor.withArgs("/test/deps").returns(false);
 
-            await clearUnusedSelectivityDumps(configMock as any);
+            await clearUnusedSelectivityDumps(configMock as any, false);
 
             assert.calledOnceWith(usedDumpsTrackerMock.usedDumpsFor, "/test/deps");
             assert.notCalled(getSelectivityTestsPathStub);
@@ -647,8 +747,10 @@ describe("CDP/Selectivity", () => {
         it("should process single browser with selectivity enabled", async () => {
             configMock.getBrowserIds.returns(["chrome"]);
             configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
                 selectivity: {
                     enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
                     testDependenciesPath: "/test/deps",
                 },
             });
@@ -657,7 +759,7 @@ describe("CDP/Selectivity", () => {
             fsStub.access.resolves();
             fsStub.readdir.resolves([]);
 
-            await clearUnusedSelectivityDumps(configMock as any);
+            await clearUnusedSelectivityDumps(configMock as any, false);
 
             assert.calledOnceWith(getSelectivityTestsPathStub, "/test/deps");
             assert.calledOnceWith(fsStub.access, "/test/deps/tests", 6); // R_OK | W_OK = 4 | 2 = 6
@@ -669,15 +771,19 @@ describe("CDP/Selectivity", () => {
             configMock.forBrowser
                 .withArgs("chrome")
                 .returns({
+                    lastFailed: { only: false },
                     selectivity: {
                         enabled: SelectivityMode.Enabled,
+                        saveIncompleteDumpOnFail: false,
                         testDependenciesPath: "/test/shared",
                     },
                 })
                 .withArgs("firefox")
                 .returns({
+                    lastFailed: { only: false },
                     selectivity: {
                         enabled: SelectivityMode.Enabled,
+                        saveIncompleteDumpOnFail: false,
                         testDependenciesPath: "/test/shared",
                     },
                 });
@@ -686,7 +792,7 @@ describe("CDP/Selectivity", () => {
             fsStub.access.resolves();
             fsStub.readdir.resolves([]);
 
-            await clearUnusedSelectivityDumps(configMock as any);
+            await clearUnusedSelectivityDumps(configMock as any, false);
 
             assert.calledOnceWith(getSelectivityTestsPathStub, "/test/shared");
             assert.calledOnce(fsStub.access);
@@ -698,15 +804,19 @@ describe("CDP/Selectivity", () => {
             configMock.forBrowser
                 .withArgs("chrome")
                 .returns({
+                    lastFailed: { only: false },
                     selectivity: {
                         enabled: SelectivityMode.Enabled,
+                        saveIncompleteDumpOnFail: false,
                         testDependenciesPath: "/test/chrome",
                     },
                 })
                 .withArgs("firefox")
                 .returns({
+                    lastFailed: { only: false },
                     selectivity: {
                         enabled: SelectivityMode.Enabled,
+                        saveIncompleteDumpOnFail: false,
                         testDependenciesPath: "/test/firefox",
                     },
                 });
@@ -715,7 +825,7 @@ describe("CDP/Selectivity", () => {
             fsStub.access.resolves();
             fsStub.readdir.resolves([]);
 
-            await clearUnusedSelectivityDumps(configMock as any);
+            await clearUnusedSelectivityDumps(configMock as any, false);
 
             assert.calledTwice(getSelectivityTestsPathStub);
             assert.calledWith(getSelectivityTestsPathStub.firstCall, "/test/chrome");
@@ -727,8 +837,10 @@ describe("CDP/Selectivity", () => {
         it("should skip silently if directory does not exist (ENOENT)", async () => {
             configMock.getBrowserIds.returns(["chrome"]);
             configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
                 selectivity: {
                     enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
                     testDependenciesPath: "/test/deps",
                 },
             });
@@ -739,7 +851,7 @@ describe("CDP/Selectivity", () => {
             enoentError.code = "ENOENT";
             fsStub.access.rejects(enoentError);
 
-            await clearUnusedSelectivityDumps(configMock as any);
+            await clearUnusedSelectivityDumps(configMock as any, false);
 
             assert.calledOnce(fsStub.access);
             assert.notCalled(fsStub.readdir);
@@ -749,8 +861,10 @@ describe("CDP/Selectivity", () => {
         it("should log debug message for non-ENOENT access errors", async () => {
             configMock.getBrowserIds.returns(["chrome"]);
             configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
                 selectivity: {
                     enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
                     testDependenciesPath: "/test/deps",
                 },
             });
@@ -760,7 +874,7 @@ describe("CDP/Selectivity", () => {
             const permissionError = new Error("EACCES: permission denied");
             fsStub.access.rejects(permissionError);
 
-            await clearUnusedSelectivityDumps(configMock as any);
+            await clearUnusedSelectivityDumps(configMock as any, false);
 
             assert.calledOnce(fsStub.access);
             assert.notCalled(fsStub.readdir);
@@ -774,8 +888,10 @@ describe("CDP/Selectivity", () => {
         it("should handle empty directory", async () => {
             configMock.getBrowserIds.returns(["chrome"]);
             configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
                 selectivity: {
                     enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
                     testDependenciesPath: "/test/deps",
                 },
             });
@@ -784,7 +900,7 @@ describe("CDP/Selectivity", () => {
             fsStub.access.resolves();
             fsStub.readdir.resolves([]);
 
-            await clearUnusedSelectivityDumps(configMock as any);
+            await clearUnusedSelectivityDumps(configMock as any, false);
 
             assert.calledOnce(fsStub.readdir);
             assert.notCalled(usedDumpsTrackerMock.wasUsed);
@@ -795,8 +911,10 @@ describe("CDP/Selectivity", () => {
         it("should delete unused files", async () => {
             configMock.getBrowserIds.returns(["chrome"]);
             configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
                 selectivity: {
                     enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
                     testDependenciesPath: "/test/deps",
                 },
             });
@@ -807,7 +925,7 @@ describe("CDP/Selectivity", () => {
             fsStub.readdir.resolves(["stale-test-1.json", "stale-test-2.json"]);
             fsStub.unlink.resolves();
 
-            await clearUnusedSelectivityDumps(configMock as any);
+            await clearUnusedSelectivityDumps(configMock as any, false);
 
             assert.calledTwice(usedDumpsTrackerMock.wasUsed);
             assert.calledWith(usedDumpsTrackerMock.wasUsed.firstCall, "stale-test-1", "/test/deps");
@@ -824,8 +942,10 @@ describe("CDP/Selectivity", () => {
         it("should not delete used files", async () => {
             configMock.getBrowserIds.returns(["chrome"]);
             configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
                 selectivity: {
                     enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
                     testDependenciesPath: "/test/deps",
                 },
             });
@@ -835,7 +955,7 @@ describe("CDP/Selectivity", () => {
             fsStub.access.resolves();
             fsStub.readdir.resolves(["used-test-1.json", "used-test-2.json"]);
 
-            await clearUnusedSelectivityDumps(configMock as any);
+            await clearUnusedSelectivityDumps(configMock as any, false);
 
             assert.calledTwice(usedDumpsTrackerMock.wasUsed);
             assert.notCalled(fsStub.unlink);
@@ -845,8 +965,10 @@ describe("CDP/Selectivity", () => {
         it("should handle mix of used and unused files", async () => {
             configMock.getBrowserIds.returns(["chrome"]);
             configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
                 selectivity: {
                     enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
                     testDependenciesPath: "/test/deps",
                 },
             });
@@ -863,7 +985,7 @@ describe("CDP/Selectivity", () => {
             fsStub.readdir.resolves(["stale-test.json", "fresh-test.json", "another-stale.json"]);
             fsStub.unlink.resolves();
 
-            await clearUnusedSelectivityDumps(configMock as any);
+            await clearUnusedSelectivityDumps(configMock as any, false);
 
             assert.calledThrice(usedDumpsTrackerMock.wasUsed);
             assert.calledTwice(fsStub.unlink);
@@ -878,8 +1000,10 @@ describe("CDP/Selectivity", () => {
         it("should handle unlink errors gracefully", async () => {
             configMock.getBrowserIds.returns(["chrome"]);
             configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
                 selectivity: {
                     enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
                     testDependenciesPath: "/test/deps",
                 },
             });
@@ -896,7 +1020,7 @@ describe("CDP/Selectivity", () => {
                 .withArgs("/test/deps/tests/stale-test-2.json")
                 .resolves();
 
-            await clearUnusedSelectivityDumps(configMock as any);
+            await clearUnusedSelectivityDumps(configMock as any, false);
 
             assert.calledTwice(fsStub.unlink);
             assert.calledTwice(debugSelectivityStub);
@@ -914,8 +1038,10 @@ describe("CDP/Selectivity", () => {
         it("should skip files without .json extension", async () => {
             configMock.getBrowserIds.returns(["chrome"]);
             configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
                 selectivity: {
                     enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
                     testDependenciesPath: "/test/deps",
                 },
             });
@@ -926,7 +1052,7 @@ describe("CDP/Selectivity", () => {
             fsStub.readdir.resolves(["some-dir", "stale-file.json"]);
             fsStub.unlink.resolves();
 
-            await clearUnusedSelectivityDumps(configMock as any);
+            await clearUnusedSelectivityDumps(configMock as any, false);
 
             assert.calledOnceWith(usedDumpsTrackerMock.wasUsed, "stale-file", "/test/deps");
             assert.calledOnceWith(fsStub.unlink, "/test/deps/tests/stale-file.json");
@@ -939,8 +1065,10 @@ describe("CDP/Selectivity", () => {
         it("should not log if no files were deleted", async () => {
             configMock.getBrowserIds.returns(["chrome"]);
             configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
                 selectivity: {
                     enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
                     testDependenciesPath: "/test/deps",
                 },
             });
@@ -950,11 +1078,68 @@ describe("CDP/Selectivity", () => {
             fsStub.access.resolves();
             fsStub.readdir.resolves(["used-test.json"]);
 
-            await clearUnusedSelectivityDumps(configMock as any);
+            await clearUnusedSelectivityDumps(configMock as any, false);
 
             assert.calledOnce(usedDumpsTrackerMock.wasUsed);
             assert.notCalled(fsStub.unlink);
             assert.notCalled(debugSelectivityStub);
+        });
+
+        it("should skip cleanup when run is failed and saveIncompleteDumpOnFail is false", async () => {
+            configMock.getBrowserIds.returns(["chrome"]);
+            configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
+                selectivity: {
+                    enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: false,
+                    testDependenciesPath: "/test/deps",
+                },
+            });
+
+            await clearUnusedSelectivityDumps(configMock as any, true);
+
+            assert.notCalled(usedDumpsTrackerMock.usedDumpsFor);
+            assert.notCalled(getSelectivityTestsPathStub);
+            assert.notCalled(fsStub.access);
+        });
+
+        it("should proceed with cleanup when run is failed and saveIncompleteDumpOnFail is true", async () => {
+            configMock.getBrowserIds.returns(["chrome"]);
+            configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: false },
+                selectivity: {
+                    enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: true,
+                    testDependenciesPath: "/test/deps",
+                },
+            });
+
+            usedDumpsTrackerMock.usedDumpsFor.returns(true);
+            fsStub.access.resolves();
+            fsStub.readdir.resolves([]);
+
+            await clearUnusedSelectivityDumps(configMock as any, true);
+
+            assert.calledOnce(usedDumpsTrackerMock.usedDumpsFor);
+            assert.calledOnce(fsStub.access);
+        });
+
+        it("should skip cleanup when lastFailed.only is true", async () => {
+            configMock.getBrowserIds.returns(["chrome"]);
+            configMock.forBrowser.withArgs("chrome").returns({
+                lastFailed: { only: true },
+                selectivity: {
+                    enabled: SelectivityMode.Enabled,
+                    saveIncompleteDumpOnFail: true,
+                    testDependenciesPath: "/test/deps",
+                },
+            });
+
+            await clearUnusedSelectivityDumps(configMock as any, false);
+
+            assert.notCalled(usedDumpsTrackerMock.usedDumpsFor);
+            assert.notCalled(getSelectivityTestsPathStub);
+            assert.notCalled(fsStub.access);
         });
     });
 });

--- a/test/src/browser/cdp/selectivity/runner.ts
+++ b/test/src/browser/cdp/selectivity/runner.ts
@@ -16,7 +16,7 @@ describe("SelectivityRunner", () => {
     let getTestSelectivityDumpIdStub: SinonStub;
     let usedDumpsTrackerMock: { trackUsed: SinonStub; usedDumpsFor: SinonStub; wasUsed: SinonStub };
     let fsExtraStub: { outputJson: SinonStub };
-    let loggerStub: { error: SinonStub };
+    let loggerStub: { error: SinonStub; warn: SinonStub };
 
     let mainRunnerMock: { on: SinonStub };
     let configMock: { forBrowser: SinonStub; getBrowserIds: SinonStub };
@@ -31,7 +31,7 @@ describe("SelectivityRunner", () => {
         getHashWriterStub = sandbox.stub();
         getTestDependenciesReaderStub = sandbox.stub();
         fsExtraStub = { outputJson: sandbox.stub().resolves() };
-        loggerStub = { error: sandbox.stub() };
+        loggerStub = { error: sandbox.stub(), warn: sandbox.stub() };
 
         usedDumpsTrackerMock = {
             trackUsed: sandbox.stub(),
@@ -111,7 +111,9 @@ describe("SelectivityRunner", () => {
                 testDependenciesPath: string;
                 compression: string;
                 disableSelectivityPatterns: string[];
+                saveIncompleteDumpOnFail: boolean;
             };
+            lastFailed: { only: boolean };
         };
         let testMock: Test;
 
@@ -122,7 +124,9 @@ describe("SelectivityRunner", () => {
                     testDependenciesPath: "/test/path",
                     compression: "none",
                     disableSelectivityPatterns: [],
+                    saveIncompleteDumpOnFail: false,
                 },
+                lastFailed: { only: false },
             };
             testMock = {
                 id: "test-123",
@@ -373,7 +377,9 @@ describe("SelectivityRunner", () => {
                     testDependenciesPath: "/test/chrome",
                     compression: "none",
                     disableSelectivityPatterns: ["src/**/*.js"],
+                    saveIncompleteDumpOnFail: false,
                 },
+                lastFailed: { only: false },
             };
             const firefoxConfig = {
                 selectivity: {
@@ -381,7 +387,9 @@ describe("SelectivityRunner", () => {
                     testDependenciesPath: "/test/firefox",
                     compression: "gz",
                     disableSelectivityPatterns: ["test/**/*.js"],
+                    saveIncompleteDumpOnFail: false,
                 },
+                lastFailed: { only: false },
             };
 
             configMock.forBrowser.withArgs("chrome").returns(chromeConfig);
@@ -398,6 +406,96 @@ describe("SelectivityRunner", () => {
             await runner.runNecessaryTests();
 
             assert.notCalled(runTestFnMock);
+        });
+
+        it("should run all tests and log warning when lastFailed.only is true and saveIncompleteDumpOnFail is false", async () => {
+            browserConfigMock.lastFailed.only = true;
+            browserConfigMock.selectivity.saveIncompleteDumpOnFail = false;
+            browserConfigMock.selectivity.disableSelectivityPatterns = [];
+
+            const testDeps = { css: [], js: ["src/app.js"], modules: [] };
+            testDepsReaderMock.getFor.resolves(testDeps);
+            hashReaderMock.getTestChangedDeps.resolves(null);
+
+            runner.startTestCheckToRun(testMock, "chrome");
+            await runner.runNecessaryTests();
+
+            assert.calledOnce(runTestFnMock);
+            assert.calledWith(loggerStub.warn, "Disabling selectivity for chrome: lastFailedOnly mode is enabled");
+        });
+
+        it("should run all tests and log debug message when lastFailed.only is true and saveIncompleteDumpOnFail is true", async () => {
+            const testMockB = { ...testMock, id: testMock.id + "_2" } as Test;
+            browserConfigMock.lastFailed.only = true;
+            browserConfigMock.selectivity.saveIncompleteDumpOnFail = true;
+            browserConfigMock.selectivity.disableSelectivityPatterns = [];
+
+            const testDepsA = { css: [], js: ["src/app.js"], modules: [] };
+            const testDepsB = { css: ["src/styles.css"], js: ["src/known.js"], modules: [] };
+            testDepsReaderMock.getFor.withArgs(testMock).resolves(testDepsA);
+            testDepsReaderMock.getFor.withArgs(testMockB).resolves(testDepsB);
+            hashReaderMock.getTestChangedDeps
+                .withArgs(testDepsA)
+                .resolves({ css: [], js: ["src/app.js"], modules: [] });
+            hashReaderMock.getTestChangedDeps.withArgs(testDepsB).resolves(null);
+
+            runner.startTestCheckToRun(testMock, "chrome");
+            runner.startTestCheckToRun(testMockB, "chrome");
+
+            await runner.runNecessaryTests();
+
+            assert.calledTwice(runTestFnMock);
+            assert.calledWith(runTestFnMock, testMock);
+            assert.calledWith(runTestFnMock, testMockB);
+            assert.notCalled(loggerStub.warn);
+            assert.calledWith(debugSelectivityStub, "Not skipping tests for chrome: lastFailedOnly mode controls it");
+        });
+
+        it("should not mix browsers cache with different lastFailed.only value", async () => {
+            browserConfigMock.selectivity.disableSelectivityPatterns = ["src/**/*.js"];
+            hashReaderMock.patternHasChanged.resolves(false);
+
+            const testDeps = { css: [], js: ["src/app.js"], modules: [] };
+            testDepsReaderMock.getFor.resolves(testDeps);
+            hashReaderMock.getTestChangedDeps.resolves(null);
+
+            const chromeConfigA = {
+                selectivity: {
+                    enabled: SelectivityMode.Enabled,
+                    testDependenciesPath: "/test/path",
+                    compression: "none",
+                    disableSelectivityPatterns: ["src/**/*.js"],
+                    saveIncompleteDumpOnFail: false,
+                },
+                lastFailed: { only: false },
+            };
+            const chromeConfigB = {
+                selectivity: {
+                    enabled: SelectivityMode.Enabled,
+                    testDependenciesPath: "/test/path",
+                    compression: "none",
+                    disableSelectivityPatterns: ["src/**/*.js"],
+                    saveIncompleteDumpOnFail: false,
+                },
+                lastFailed: { only: true },
+            };
+
+            configMock.forBrowser.withArgs("chromeA").returns(chromeConfigA);
+            configMock.forBrowser.withArgs("chromeB").returns(chromeConfigB);
+
+            const testA = { ...testMock, id: "test-a" } as Test;
+            const testB = { ...testMock, id: "test-b" } as Test;
+
+            runner.startTestCheckToRun(testB, "chromeB");
+            await runner.runNecessaryTests();
+
+            assert.notCalled(hashReaderMock.patternHasChanged);
+
+            runner.startTestCheckToRun(testA, "chromeA");
+
+            await runner.runNecessaryTests();
+
+            assert.calledOnce(hashReaderMock.patternHasChanged);
         });
     });
 
@@ -421,7 +519,9 @@ describe("SelectivityRunner", () => {
                     testDependenciesPath: "/test/path",
                     compression: "none",
                     disableSelectivityPatterns: [],
+                    saveIncompleteDumpOnFail: false,
                 },
+                lastFailed: { only: false },
             };
             const testMock = {
                 id: "test-123",
@@ -479,7 +579,9 @@ describe("SelectivityRunner", () => {
                 compression: string;
                 disableSelectivityPatterns: string[];
                 reportPath: string;
+                saveIncompleteDumpOnFail: boolean;
             };
+            lastFailed: { only: boolean };
         };
         let testMock: Test;
 
@@ -491,7 +593,9 @@ describe("SelectivityRunner", () => {
                     compression: "none",
                     disableSelectivityPatterns: ["src/**/*.js"],
                     reportPath: "/tmp/selectivity-report.json",
+                    saveIncompleteDumpOnFail: false,
                 },
+                lastFailed: { only: false },
             };
             testMock = {
                 id: "test-123",
@@ -576,7 +680,9 @@ describe("SelectivityRunner", () => {
                     compression: "none",
                     disableSelectivityPatterns: ["src/**/*.js"],
                     reportPath: "/tmp/selectivity-report.json",
+                    saveIncompleteDumpOnFail: false,
                 },
+                lastFailed: { only: false },
             };
             const firefoxConfig = {
                 selectivity: {
@@ -585,7 +691,9 @@ describe("SelectivityRunner", () => {
                     compression: "none",
                     disableSelectivityPatterns: ["src/**/*.js"],
                     reportPath: "/tmp/selectivity-report.json",
+                    saveIncompleteDumpOnFail: false,
                 },
+                lastFailed: { only: false },
             };
 
             configMock.forBrowser.withArgs("chrome").returns(chromeConfig);
@@ -625,7 +733,9 @@ describe("SelectivityRunner", () => {
                     compression: "none",
                     disableSelectivityPatterns: ["src/**/*.js"],
                     reportPath: "/tmp/chrome-report.json",
+                    saveIncompleteDumpOnFail: false,
                 },
+                lastFailed: { only: false },
             };
             const firefoxConfig = {
                 selectivity: {
@@ -634,7 +744,9 @@ describe("SelectivityRunner", () => {
                     compression: "none",
                     disableSelectivityPatterns: ["src/**/*.js"],
                     reportPath: "/tmp/firefox-report.json",
+                    saveIncompleteDumpOnFail: false,
                 },
+                lastFailed: { only: false },
             };
 
             configMock.forBrowser.withArgs("chrome").returns(chromeConfig);


### PR DESCRIPTION
## Issue

If test run is failed, all dumps are lost, and we have to rerun all tests.

## Solution

We can save incomplete data (in cooperation with lastFailedOnly mode) in order to rerun only failed tests, which is much faster