### PR TITLE
fix: fix issues with openAndWait timeouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@testplane/devtools": "8.32.5",
         "@testplane/wdio-protocols": "9.4.7",
         "@testplane/wdio-utils": "9.5.4",
-        "@testplane/webdriverio": "9.5.27",
+        "@testplane/webdriverio": "9.5.28",
         "@vitest/spy": "2.1.4",
         "buffer-crc32": "1.0.0",
         "chalk": "2.4.2",
@@ -2849,9 +2849,10 @@
       }
     },
     "node_modules/@testplane/webdriverio": {
-      "version": "9.5.27",
-      "resolved": "https://registry.npmjs.org/@testplane/webdriverio/-/webdriverio-9.5.27.tgz",
-      "integrity": "sha512-9F0+i6h7szzFuRbZmucwJH6mEnLA1I3AaL2TXZL+GlVPRaC/P0KbsJhAs8u2BJDb+0kakE3BZ9Mr7zhBeCIEuw==",
+      "version": "9.5.28",
+      "resolved": "https://registry.npmjs.org/@testplane/webdriverio/-/webdriverio-9.5.28.tgz",
+      "integrity": "sha512-UWkAOFhhL5DYquwDsr0JnjD5TMC0/drlrUJFWHz6t+s9y8el5z0B+5WJX6xsrjn3q4HyqMCpALNTFZLJCNqj0Q==",
+      "license": "MIT",
       "dependencies": {
         "@testplane/wdio-config": "9.5.3",
         "@testplane/wdio-logger": "9.4.6",
@@ -16272,9 +16273,9 @@
       }
     },
     "@testplane/webdriverio": {
-      "version": "9.5.27",
-      "resolved": "https://registry.npmjs.org/@testplane/webdriverio/-/webdriverio-9.5.27.tgz",
-      "integrity": "sha512-9F0+i6h7szzFuRbZmucwJH6mEnLA1I3AaL2TXZL+GlVPRaC/P0KbsJhAs8u2BJDb+0kakE3BZ9Mr7zhBeCIEuw==",
+      "version": "9.5.28",
+      "resolved": "https://registry.npmjs.org/@testplane/webdriverio/-/webdriverio-9.5.28.tgz",
+      "integrity": "sha512-UWkAOFhhL5DYquwDsr0JnjD5TMC0/drlrUJFWHz6t+s9y8el5z0B+5WJX6xsrjn3q4HyqMCpALNTFZLJCNqj0Q==",
       "requires": {
         "@testplane/wdio-config": "9.5.3",
         "@testplane/wdio-logger": "9.4.6",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@testplane/devtools": "8.32.5",
     "@testplane/wdio-protocols": "9.4.7",
     "@testplane/wdio-utils": "9.5.4",
-    "@testplane/webdriverio": "9.5.27",
+    "@testplane/webdriverio": "9.5.28",
     "@vitest/spy": "2.1.4",
     "buffer-crc32": "1.0.0",
     "chalk": "2.4.2",

--- a/src/browser/commands/openAndWait.ts
+++ b/src/browser/commands/openAndWait.ts
@@ -101,9 +101,39 @@ const makeOpenAndWaitCommand = (config: BrowserConfig, session: WebdriverIO.Brow
             };
 
             const goToPage = async (): Promise<void> => {
-                await session.url(uri, { timeout }).finally(() => {
-                    restorePageLoadTimeout();
-                });
+                const promises: Promise<unknown>[] = [];
+
+                promises.push(
+                    session.url(uri, { timeout, _noFallbackOnCancel: true }).finally(() => {
+                        restorePageLoadTimeout();
+                    }),
+                );
+
+                let hardTimeoutId: NodeJS.Timeout | undefined;
+
+                /* BiDi doesn't respect pageLoadTimeout, so we need to set a hard timeout and cancel previous navigation
+                 * by navigating to about:blank */
+                if (session.isBidi) {
+                    promises.push(
+                        new Promise<never>((_, reject) => {
+                            hardTimeoutId = setTimeout(async () => {
+                                await session.url(emptyPageUrl);
+
+                                reject(
+                                    new Error(
+                                        `openAndWait timed out after ${timeout}ms while trying to navigate to ${uri}`,
+                                    ),
+                                );
+                            }, timeout);
+                        }),
+                    );
+                }
+
+                try {
+                    await Promise.race(promises);
+                } finally {
+                    clearTimeout(hardTimeoutId);
+                }
             };
 
             pageLoader.on("pageLoadError", handleError);

--- a/src/browser/commands/openAndWait.ts
+++ b/src/browser/commands/openAndWait.ts
@@ -113,7 +113,7 @@ const makeOpenAndWaitCommand = (config: BrowserConfig, session: WebdriverIO.Brow
 
                 /* BiDi doesn't respect pageLoadTimeout, so we need to set a hard timeout and cancel previous navigation
                  * by navigating to about:blank */
-                if (session.isBidi) {
+                if (session.isBidi && timeout > 0) {
                     promises.push(
                         new Promise<never>((_, reject) => {
                             hardTimeoutId = setTimeout(async () => {

--- a/src/browser/commands/openAndWait.ts
+++ b/src/browser/commands/openAndWait.ts
@@ -89,18 +89,6 @@ const makeOpenAndWaitCommand = (config: BrowserConfig, session: WebdriverIO.Brow
             await setPageLoadTimeout(timeout);
         }
 
-        // Create hard timeout promise to guarantee timeout is respected
-        // This is needed because WebDriver pageLoad timeout only affects the browser's
-        // page load event, not the HTTP connection/response time
-        let hardTimeoutId: NodeJS.Timeout | undefined;
-        const hardTimeoutPromise = timeout
-            ? new Promise<never>((_, reject) => {
-                  hardTimeoutId = setTimeout(() => {
-                      reject(new Error(`openAndWait timed out after ${timeout}ms`));
-                  }, timeout);
-              })
-            : null;
-
         const loadPromise = new Promise<void>((resolve, reject) => {
             const handleError = (err: Error): void => {
                 reject(new Error(`url: ${err.message}`));
@@ -113,7 +101,9 @@ const makeOpenAndWaitCommand = (config: BrowserConfig, session: WebdriverIO.Brow
             };
 
             const goToPage = async (): Promise<void> => {
-                await session.url(uri, { timeout });
+                await session.url(uri, { timeout }).finally(() => {
+                    restorePageLoadTimeout();
+                });
             };
 
             pageLoader.on("pageLoadError", handleError);
@@ -148,19 +138,7 @@ const makeOpenAndWaitCommand = (config: BrowserConfig, session: WebdriverIO.Brow
             pageLoader.load(goToPage).then(checkLoaded);
         });
 
-        const racePromises: Promise<void>[] = [loadPromise];
-        if (hardTimeoutPromise) {
-            racePromises.push(hardTimeoutPromise);
-        }
-
-        return Promise.race(racePromises).finally(() => {
-            if (hardTimeoutId) {
-                clearTimeout(hardTimeoutId);
-            }
-            // No await, because session might be stuck on url() command
-            pageLoader.unsubscribe();
-            restorePageLoadTimeout();
-        });
+        return loadPromise.finally(() => pageLoader.unsubscribe());
     };
 
 export type OpenAndWaitCommand = ReturnType<typeof makeOpenAndWaitCommand>;

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -32,7 +32,7 @@ export const assertOptionalArray = (value: unknown, name: string): void => {
 
 export const assertNonNegativeInteger = (value: number, name: string): void => {
     if (!Number.isInteger(value) || value < 0) {
-        throw new Error(`"${name}" must be a non-negative integer`);
+        throw new Error(`"${name}" must be a non-negative integer, got ${value} of type ${typeof value}`);
     }
 };
 


### PR DESCRIPTION
### What's done?

This PR fixes many issues that `openAndWait` had with page load timeout handling:
- it's incorrect to just throw on timeout, because even though client fails fast, browser remains in stuck state and can't handle subsequent commands rendering this "fast fail" pointless
- improved page load timeout restoration logic
- bidi required a completely different approach to timeouts handling

Check out related PRs on webdriverio's side:
- https://github.com/gemini-testing/webdriverio/pull/41
- https://github.com/gemini-testing/webdriverio/pull/42

This PR uses builds based on those branches.