### PR TITLE
fix: do not enforce return types for beforeAll/afterAll hook

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -467,7 +467,7 @@ type PartialCommonConfig = Partial<
     selectivity?: Partial<CommonConfig["selectivity"]>;
 };
 
-export type HookType = (params: { config: Config }) => Promise<void> | undefined;
+export type HookType = (params: { config: Config }) => Promise<unknown> | unknown;
 
 // Only browsers desiredCapabilities are required in input config
 export type ConfigInput = Partial<PartialCommonConfig> & {


### PR DESCRIPTION
### What's done?

Adjusted typings for `beforeAll/afterAll` hooks to allow users:
```
afterAll: () => console.log('afterAll')
```