### PR TITLE
fix: do not send rrweb script on each snapshot request

### DIFF
--- a/src/browser/history/index.ts
+++ b/src/browser/history/index.ts
@@ -3,7 +3,8 @@ import { Callstack } from "./callstack";
 import * as cmds from "./commands";
 import { isGroup, normalizeCommandArgs, runWithHooks, shouldRecordSnapshots } from "./utils";
 import { BrowserConfig } from "../../config/browser-config";
-import { TestStep, TestStepKey } from "../../types";
+import { TestStepKey } from "../../types";
+import type { Test, TestStep } from "../../types";
 import { filterEvents, installRrwebAndCollectEvents, sendFilteredEvents } from "./rrweb";
 import { getHistoryContext, runWithHistoryContext } from "./async-local-storage";
 
@@ -61,8 +62,48 @@ interface RunWithHistoryHooksData<T> extends HooksData {
     fn: () => T;
 }
 
+interface RequestDomSnapshotsData extends HooksData {
+    attempt?: number;
+    currentTest?: Test;
+}
+
 export const runWithoutHistory = async <T>(_: unknown, fn: () => T): Promise<T> => {
     return runWithHistoryContext({ shouldBypassHistory: true }, fn) as T;
+};
+
+export const requestDomSnapshots = ({
+    session,
+    callstack,
+    snapshotsPromiseRef,
+    config,
+    attempt,
+    currentTest,
+}: RequestDomSnapshotsData): void => {
+    try {
+        if (!callstack) {
+            return;
+        }
+
+        const timeTravelMode = config.timeTravel.mode;
+        const isRetry = (attempt ?? session.executionContext?.ctx?.attempt ?? 0) > 0;
+        const shouldRecord = shouldRecordSnapshots(timeTravelMode, isRetry);
+        const test = currentTest ?? session.executionContext?.ctx?.currentTest;
+
+        if (shouldRecord && process.send && test) {
+            const rrwebPromise = installRrwebAndCollectEvents(session, callstack)
+                .then(rrwebEvents => {
+                    const rrwebEventsFiltered = filterEvents(rrwebEvents);
+                    sendFilteredEvents(test, rrwebEventsFiltered);
+                })
+                .catch(e => {
+                    debug("An error occurred during capturing snapshots in browser: %O", e);
+                });
+
+            snapshotsPromiseRef.current = snapshotsPromiseRef.current.then(() => rrwebPromise);
+        }
+    } catch (e) {
+        debug("An error occurred during capturing snapshots in browser: %O", e);
+    }
 };
 
 const runWithHistoryHooks = <T>({
@@ -88,30 +129,14 @@ const runWithHistoryHooks = <T>({
 
             if (typeof (result as Promise<unknown> | undefined)?.then === "function") {
                 try {
-                    const timeTravelMode = config.timeTravel.mode;
-                    const isRetry = (session.executionContext?.ctx?.attempt ?? 0) > 0;
-                    const shouldRecord = shouldRecordSnapshots(timeTravelMode, isRetry);
                     const isInterestingStep =
                         !nodeData.name.startsWith("is") &&
                         !nodeData.name.startsWith("get") &&
                         !nodeData.name.startsWith("$") &&
                         !nodeData.name.startsWith("wait");
 
-                    if (
-                        shouldRecord &&
-                        process.send &&
-                        session.executionContext?.ctx?.currentTest &&
-                        isInterestingStep
-                    ) {
-                        const rrwebPromise = installRrwebAndCollectEvents(session, callstack)
-                            ?.then(rrwebEvents => {
-                                const rrwebEventsFiltered = filterEvents(rrwebEvents);
-                                sendFilteredEvents(session, rrwebEventsFiltered);
-                            })
-                            .catch(e => {
-                                debug("An error occurred during capturing snapshots in browser: %O", e);
-                            });
-                        snapshotsPromiseRef.current = snapshotsPromiseRef.current.then(() => rrwebPromise);
+                    if (isInterestingStep) {
+                        requestDomSnapshots({ session, callstack, snapshotsPromiseRef, config });
                     }
                 } catch (e) {
                     debug("An error occurred during capturing snapshots in browser: %O", e);

--- a/src/browser/history/index.ts
+++ b/src/browser/history/index.ts
@@ -5,7 +5,7 @@ import { isGroup, normalizeCommandArgs, runWithHooks, shouldRecordSnapshots } fr
 import { BrowserConfig } from "../../config/browser-config";
 import { TestStepKey } from "../../types";
 import type { Test, TestStep } from "../../types";
-import { filterEvents, installRrwebAndCollectEvents, sendFilteredEvents } from "./rrweb";
+import { cleanupRrweb, filterEvents, installRrwebAndCollectEvents, sendFilteredEvents } from "./rrweb";
 import { getHistoryContext, runWithHistoryContext } from "./async-local-storage";
 
 const debug = makeDebug("testplane:browser:history");
@@ -103,6 +103,20 @@ export const requestDomSnapshots = ({
         }
     } catch (e) {
         debug("An error occurred during capturing snapshots in browser: %O", e);
+    }
+};
+
+type CleanupDomSnapshotsData = Pick<HooksData, "session" | "callstack">;
+
+export const cleanupDomSnapshots = async ({ session, callstack }: CleanupDomSnapshotsData): Promise<void> => {
+    if (!callstack) {
+        return;
+    }
+
+    try {
+        await cleanupRrweb(session, callstack);
+    } catch (e) {
+        debug("An error occurred during cleaning up snapshots in browser: %O", e);
     }
 };
 

--- a/src/browser/history/rrweb.ts
+++ b/src/browser/history/rrweb.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import { eventWithTime } from "@rrweb/types";
 import type { Callstack } from "./callstack";
 import { MasterEvents } from "../../events";
-import { SnapshotsData, TestContext } from "../../types";
+import type { SnapshotsData, Test, TestContext } from "../../types";
 import { runWithoutHistory } from "./index";
 import path from "path";
 
@@ -173,8 +173,7 @@ export function filterEvents(rrwebEvents: eventWithTime[]): eventWithTime[] {
     });
 }
 
-export function sendFilteredEvents(session: WebdriverIO.Browser, rrwebEvents: eventWithTime[]): void {
-    const currentTest = session.executionContext?.ctx?.currentTest;
+export function sendFilteredEvents(currentTest: Test | undefined, rrwebEvents: eventWithTime[]): void {
     if (rrwebEvents.length > 0 && process.send && currentTest) {
         process.send({
             event: MasterEvents.DOM_SNAPSHOTS,

--- a/src/browser/history/rrweb.ts
+++ b/src/browser/history/rrweb.ts
@@ -10,94 +10,52 @@ import path from "path";
 // PR: https://github.com/rrweb-io/rrweb/pull/1735
 // Issue: https://github.com/rrweb-io/rrweb/issues/1734
 const rrwebCode = fs.readFileSync(path.join(__dirname, "../client-scripts/rrweb-record.min.js"), "utf-8");
+const sessionsWithRrwebRequested = new WeakSet<WebdriverIO.Browser>();
 
+interface CollectRrwebEventsResult {
+    isRrwebInstalled: boolean;
+    rrwebEvents: eventWithTime[];
+}
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 export async function installRrwebAndCollectEvents(
     session: WebdriverIO.Browser,
     callstack: Callstack,
 ): Promise<eventWithTime[]> {
-    /* eslint-disable @typescript-eslint/ban-ts-comment */
-    return runWithoutHistory<Promise<eventWithTime[]>>({ callstack }, () =>
-        session.execute(
-            (rrwebRecordFnCode, serverTime) => {
-                const getRealTimestamp = (fallbackTime: number = 0): number => {
-                    const nativeCode = "[native code]";
+    return runWithoutHistory<Promise<eventWithTime[]>>({ callstack }, async () => {
+        const shouldSendRrwebCode = !sessionsWithRrwebRequested.has(session);
 
-                    try {
-                        if (Date.now.toString().includes(nativeCode)) {
-                            return Date.now();
-                        }
-                    } catch (e) {
-                        /**/
-                    }
+        if (shouldSendRrwebCode) {
+            sessionsWithRrwebRequested.add(session);
+        }
 
-                    try {
-                        if (new Date().getTime.toString().includes(nativeCode)) {
-                            return new Date().getTime();
-                        }
-                    } catch (e) {
-                        /**/
-                    }
+        const result = await collectRrwebEvents(session, shouldSendRrwebCode ? rrwebCode : null);
 
-                    try {
-                        if (new Date().valueOf.toString().includes(nativeCode)) {
-                            return new Date().valueOf();
-                        }
-                    } catch (e) {
-                        /**/
-                    }
+        if (result.isRrwebInstalled || shouldSendRrwebCode) {
+            return result.rrwebEvents;
+        }
 
-                    try {
-                        if (performance.now.toString().includes(nativeCode)) {
-                            return Math.floor(performance.timeOrigin + performance.now());
-                        }
-                    } catch (e) {
-                        /**/
-                    }
+        return (await collectRrwebEvents(session, rrwebCode)).rrwebEvents;
+    });
+}
 
-                    return fallbackTime;
-                };
-
+function collectRrwebEvents(
+    session: WebdriverIO.Browser,
+    rrwebRecordFnCode: string | null,
+): Promise<CollectRrwebEventsResult> {
+    return session.execute(
+        (rrwebRecordFnCode, serverTime) => {
+            const isRrwebInstalled = (): boolean => {
                 try {
                     // @ts-expect-error
-                    if (!window.rrweb) {
-                        window.eval(rrwebRecordFnCode);
-                        // @ts-expect-error
-                        window.lastProcessedRrwebEvent = -1;
-                        // @ts-expect-error
-                        window.rrwebEvents = [];
-
-                        // @ts-expect-error
-                        window.rrweb.record({
-                            // @ts-expect-error
-                            emit(event) {
-                                event.timestamp = getRealTimestamp(serverTime);
-
-                                // @ts-expect-error
-                                window.rrwebEvents.push(event);
-                            },
-                        });
-
-                        // @ts-expect-error
-                        window.rrweb.record.addCustomEvent("color-scheme-change", {
-                            colorScheme:
-                                window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
-                                    ? "dark"
-                                    : "light",
-                        });
-
-                        window.matchMedia &&
-                            window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", event => {
-                                // @ts-expect-error
-                                window.rrweb.record.addCustomEvent("color-scheme-change", {
-                                    colorScheme: event.matches ? "dark" : "light",
-                                });
-                            });
-                    }
-                } catch (e) {
-                    /**/
+                    return Boolean(window.rrweb);
+                } catch {
+                    return false;
                 }
+            };
 
-                let result;
+            const getRrwebEvents = (): eventWithTime[] => {
+                let result: eventWithTime[];
                 try {
                     // @ts-expect-error
                     result = window.rrwebEvents.slice(window.lastProcessedRrwebEvent + 1);
@@ -108,13 +66,102 @@ export async function installRrwebAndCollectEvents(
                 }
 
                 return result;
-            },
-            rrwebCode,
-            Date.now(),
-        ),
+            };
+
+            const getRealTimestamp = (fallbackTime: number = 0): number => {
+                const nativeCode = "[native code]";
+
+                try {
+                    if (Date.now.toString().includes(nativeCode)) {
+                        return Date.now();
+                    }
+                } catch (e) {
+                    /**/
+                }
+
+                try {
+                    if (new Date().getTime.toString().includes(nativeCode)) {
+                        return new Date().getTime();
+                    }
+                } catch (e) {
+                    /**/
+                }
+
+                try {
+                    if (new Date().valueOf.toString().includes(nativeCode)) {
+                        return new Date().valueOf();
+                    }
+                } catch (e) {
+                    /**/
+                }
+
+                try {
+                    if (performance.now.toString().includes(nativeCode)) {
+                        return Math.floor(performance.timeOrigin + performance.now());
+                    }
+                } catch (e) {
+                    /**/
+                }
+
+                return fallbackTime;
+            };
+
+            try {
+                if (!isRrwebInstalled() && rrwebRecordFnCode) {
+                    window.eval(rrwebRecordFnCode);
+                    // @ts-expect-error
+                    window.lastProcessedRrwebEvent = -1;
+                    // @ts-expect-error
+                    window.rrwebEvents = [];
+
+                    // @ts-expect-error
+                    window.rrweb.record({
+                        // @ts-expect-error
+                        emit(event) {
+                            event.timestamp = getRealTimestamp(serverTime);
+
+                            // @ts-expect-error
+                            window.rrwebEvents.push(event);
+                        },
+                    });
+
+                    // @ts-expect-error
+                    window.rrweb.record.addCustomEvent("color-scheme-change", {
+                        colorScheme:
+                            window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+                                ? "dark"
+                                : "light",
+                    });
+
+                    window.matchMedia &&
+                        window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", event => {
+                            // @ts-expect-error
+                            window.rrweb.record.addCustomEvent("color-scheme-change", {
+                                colorScheme: event.matches ? "dark" : "light",
+                            });
+                        });
+                }
+            } catch (e) {
+                /**/
+            }
+
+            if (!isRrwebInstalled()) {
+                return {
+                    isRrwebInstalled: false,
+                    rrwebEvents: [],
+                };
+            }
+
+            return {
+                isRrwebInstalled: true,
+                rrwebEvents: getRrwebEvents(),
+            };
+        },
+        rrwebRecordFnCode,
+        Date.now(),
     );
-    /* eslint-enable @typescript-eslint/ban-ts-comment */
 }
+/* eslint-enable @typescript-eslint/ban-ts-comment */
 
 export function filterEvents(rrwebEvents: eventWithTime[]): eventWithTime[] {
     return rrwebEvents.filter(e => {

--- a/src/browser/history/rrweb.ts
+++ b/src/browser/history/rrweb.ts
@@ -39,6 +39,57 @@ export async function installRrwebAndCollectEvents(
     });
 }
 
+export async function cleanupRrweb(session: WebdriverIO.Browser, callstack: Callstack): Promise<void> {
+    try {
+        await runWithoutHistory<Promise<void>>({ callstack }, () =>
+            session.execute(() => {
+                try {
+                    // @ts-expect-error
+                    const rrwebEvents = window.rrwebEvents;
+                    const rrwebData = rrwebEvents?.testplane;
+
+                    if (rrwebData?.stopRecording) {
+                        try {
+                            rrwebData.stopRecording();
+                        } catch (e) {
+                            /**/
+                        }
+                    }
+
+                    try {
+                        const colorSchemeMedia = rrwebData?.colorSchemeMedia;
+                        const colorSchemeListener = rrwebData?.colorSchemeListener;
+
+                        if (colorSchemeMedia && colorSchemeListener) {
+                            colorSchemeMedia.removeEventListener("change", colorSchemeListener);
+                        }
+                    } catch (e) {
+                        /**/
+                    }
+
+                    if (rrwebData?.isInstalledByTestplane) {
+                        // @ts-expect-error
+                        delete window.rrweb;
+
+                        // @ts-expect-error
+                        delete window.lastProcessedRrwebEvent;
+                        // @ts-expect-error
+                        delete window.rrwebEvents;
+                    } else if (rrwebEvents) {
+                        delete rrwebEvents.testplane;
+                    }
+                } catch (e) {
+                    /**/
+                }
+            }),
+        );
+    } catch (e) {
+        /**/
+    } finally {
+        sessionsWithRrwebRequested.delete(session);
+    }
+}
+
 function collectRrwebEvents(
     session: WebdriverIO.Browser,
     rrwebRecordFnCode: string | null,
@@ -113,9 +164,16 @@ function collectRrwebEvents(
                     window.lastProcessedRrwebEvent = -1;
                     // @ts-expect-error
                     window.rrwebEvents = [];
+                    // @ts-expect-error
+                    Object.defineProperty(window.rrwebEvents, "testplane", {
+                        configurable: true,
+                        value: {
+                            isInstalledByTestplane: true,
+                        },
+                    });
 
                     // @ts-expect-error
-                    window.rrweb.record({
+                    window.rrwebEvents.testplane.stopRecording = window.rrweb.record({
                         // @ts-expect-error
                         emit(event) {
                             event.timestamp = getRealTimestamp(serverTime);
@@ -125,21 +183,27 @@ function collectRrwebEvents(
                         },
                     });
 
+                    const colorSchemeMedia = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)");
+
                     // @ts-expect-error
                     window.rrweb.record.addCustomEvent("color-scheme-change", {
-                        colorScheme:
-                            window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
-                                ? "dark"
-                                : "light",
+                        colorScheme: colorSchemeMedia && colorSchemeMedia.matches ? "dark" : "light",
                     });
 
-                    window.matchMedia &&
-                        window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", event => {
+                    if (colorSchemeMedia) {
+                        const colorSchemeListener = (event: MediaQueryListEvent): void => {
                             // @ts-expect-error
                             window.rrweb.record.addCustomEvent("color-scheme-change", {
                                 colorScheme: event.matches ? "dark" : "light",
                             });
-                        });
+                        };
+
+                        colorSchemeMedia.addEventListener("change", colorSchemeListener);
+                        // @ts-expect-error
+                        window.rrwebEvents.testplane.colorSchemeMedia = colorSchemeMedia;
+                        // @ts-expect-error
+                        window.rrwebEvents.testplane.colorSchemeListener = colorSchemeListener;
+                    }
                 }
             } catch (e) {
                 /**/

--- a/src/worker/runner/test-runner/index.js
+++ b/src/worker/runner/test-runner/index.js
@@ -236,8 +236,16 @@ module.exports = class TestRunner {
             const collectingSnapshotsMessageTimeout = setTimeout(() => {
                 console.log("Collecting Time Travel snapshots takes longer than expected. Waiting...");
             }, 2000);
-            await this._browser.snapshotsPromiseRef.current;
-            clearTimeout(collectingSnapshotsMessageTimeout);
+
+            try {
+                await this._browser.snapshotsPromiseRef.current;
+            } finally {
+                clearTimeout(collectingSnapshotsMessageTimeout);
+                await history.cleanupDomSnapshots({
+                    callstack: callstackHistory,
+                    session: this._browser.publicAPI,
+                });
+            }
         }
 
         return error;

--- a/src/worker/runner/test-runner/index.js
+++ b/src/worker/runner/test-runner/index.js
@@ -223,6 +223,15 @@ module.exports = class TestRunner {
         } catch (e) {
             error = error || e;
         } finally {
+            history.requestDomSnapshots({
+                callstack: callstackHistory,
+                snapshotsPromiseRef: this._browser.snapshotsPromiseRef,
+                config: this._config,
+                session: this._browser.publicAPI,
+                currentTest: test,
+                attempt: this._attempt,
+            });
+
             // If collecting time travel snapshots takes a lot of time, make it obvious by writing a message
             const collectingSnapshotsMessageTimeout = setTimeout(() => {
                 console.log("Collecting Time Travel snapshots takes longer than expected. Waiting...");


### PR DESCRIPTION
### What's done?

- The rrweb script is sent only on the first request in a session. Afterwards, it's only re-sent if it's not installed on the page. This allows us to significantly reduce time travel network overhead.

- Snapshots are now collected at the very end of the test as well. This fixes occasional losses of the very last state change

- There's now proper cleanup of rrweb on the page. This fixes cases when session is re-used, which previously led to broken snapshots