### PR TITLE
Fix add timetravel timeout

### DIFF
--- a/src/worker/runner/test-runner/index.js
+++ b/src/worker/runner/test-runner/index.js
@@ -14,6 +14,9 @@ const { filterExtraStackFrames } = require("../../../browser/stacktrace/utils");
 const { extendWithCodeSnippet } = require("../../../error-snippets");
 const { startSelectivity } = require("../../../browser/cdp/selectivity");
 
+const SNAPSHOTS_TIMEOUT_MS = 10000;
+const SNAPSHOTS_WARNING_TIMEOUT_MS = 2000;
+
 module.exports = class TestRunner {
     static create(...args) {
         return new this(...args);
@@ -229,13 +232,22 @@ module.exports = class TestRunner {
                 attempt: this._attempt,
             });
 
+            const snapshotsTimeout = new Promise((_, reject) =>
+                setTimeout(() => {
+                    this._browser.markAsBroken({ stubBrowserCommands: true });
+                    reject(new Error(`Collecting Time Travel snapshots timed out after ${SNAPSHOTS_TIMEOUT_MS}ms`));
+                }, SNAPSHOTS_TIMEOUT_MS),
+            );
+
             // If collecting time travel snapshots takes a lot of time, make it obvious by writing a message
             const collectingSnapshotsMessageTimeout = setTimeout(() => {
                 console.log("Collecting Time Travel snapshots takes longer than expected. Waiting...");
-            }, 2000);
+            }, SNAPSHOTS_WARNING_TIMEOUT_MS);
 
             try {
-                await this._browser.snapshotsPromiseRef.current;
+                await Promise.race([this._browser.snapshotsPromiseRef.current, snapshotsTimeout]);
+            } catch (e) {
+                console.error(e.message);
             } finally {
                 clearTimeout(collectingSnapshotsMessageTimeout);
                 await history.cleanupDomSnapshots({

--- a/test/src/worker/runner/test-runner/index.js
+++ b/test/src/worker/runner/test-runner/index.js
@@ -70,7 +70,7 @@ describe("worker/runner/test-runner", () => {
         });
         config = _.defaults(config, { resetCursor: true });
 
-        return {
+        const browser = {
             id,
             publicAPI,
             config,
@@ -79,12 +79,13 @@ describe("worker/runner/test-runner", () => {
                 isBroken: false,
             },
             snapshotsPromiseRef: { current: Promise.resolve() },
-            markAsBroken: sandbox.stub().callsFake(() => {
-                this.state.isBroken = true;
-
-                return sandbox.stub();
-            }),
         };
+        browser.markAsBroken = sandbox.stub().callsFake(() => {
+            browser.state.isBroken = true;
+
+            return sandbox.stub();
+        });
+        return browser;
     };
 
     beforeEach(() => {
@@ -1077,6 +1078,62 @@ describe("worker/runner/test-runner", () => {
             });
 
             assert.strictEqual(browser.state.isLastTestFailed, false);
+        });
+    });
+
+    describe("snapshots collection timeout", () => {
+        let clock;
+        let TimeTravelTestRunner;
+
+        const run_ = async () => {
+            const browser = mkBrowser_();
+            browser.snapshotsPromiseRef = { current: new Promise(() => {}) };
+            BrowserAgent.prototype.getBrowser.resolves(browser);
+
+            const runner = TimeTravelTestRunner.create({
+                test: mkTest_(),
+                file: "/default/file/path",
+                config: makeConfigStub(),
+                browserAgent: Object.create(BrowserAgent.prototype),
+            });
+
+            await runner.prepareBrowser({ sessionId: "session-id", sessionCaps: {}, sessionOpts: {}, state: {} });
+            return { runPromise: runner.run(), browser };
+        };
+
+        beforeEach(() => {
+            clock = sinon.useFakeTimers();
+
+            TimeTravelTestRunner = proxyquire("src/worker/runner/test-runner", {
+                "../../../browser/history": {
+                    runGroup: historyRunGroupStub,
+                    requestDomSnapshots: sandbox.stub(),
+                    cleanupDomSnapshots: sandbox.stub().resolves(),
+                },
+                "../../../browser/cdp/selectivity": {
+                    startSelectivity: sandbox.stub().resolves(() => Promise.resolve()),
+                },
+                "./capture-fail-screenshot": {
+                    captureFailScreenshot: captureFailScreenshotStub,
+                },
+            });
+        });
+
+        afterEach(() => {
+            clock.restore();
+        });
+
+        it("should log warning after 2 seconds if snapshots collection is slow and log error after 10 seconds timeout", async () => {
+            sandbox.stub(console, "error");
+            sandbox.stub(console, "log");
+
+            const { runPromise, browser } = await run_();
+            await clock.tickAsync(10000);
+            await runPromise;
+
+            assert.calledWith(console.log, "Collecting Time Travel snapshots takes longer than expected. Waiting...");
+            assert.calledWith(console.error, "Collecting Time Travel snapshots timed out after 10000ms");
+            assert.calledOnceWith(browser.markAsBroken, { stubBrowserCommands: true });
         });
     });
 });


### PR DESCRIPTION
Before this change, if Time Travel snapshot collection hung, the test runner would wait forever with only a `Collecting Time Travel snapshots takes longer than expected. Waiting...` warning. Now collection is aborted after a timeout and the run continues, logging `Collecting Time Travel snapshots timed out after 5000ms` — the 
  snapshot is simply omitted from the report.