### PR TITLE
fix: keep async context in repl calls

### DIFF
--- a/src/browser/commands/switchToRepl.ts
+++ b/src/browser/commands/switchToRepl.ts
@@ -1,3 +1,4 @@
+import { AsyncResource } from "node:async_hooks";
 import path from "node:path";
 import type repl from "node:repl";
 import net from "node:net";
@@ -56,14 +57,17 @@ export default (browser: Browser): void => {
         const lineEvents = getEventListeners(replServer, REPL_LINE_EVENT);
         replServer.removeAllListeners(REPL_LINE_EVENT);
 
-        replServer.on(REPL_LINE_EVENT, cmd => {
-            const trimmedCmd = cmd.trim();
-            const newCmd = trimmedCmd.replace(/(?<=^|\s|;|\(|\{)(let |const )/g, "var ");
+        replServer.on(
+            REPL_LINE_EVENT,
+            AsyncResource.bind(cmd => {
+                const trimmedCmd = cmd.trim();
+                const newCmd = trimmedCmd.replace(/(?<=^|\s|;|\(|\{)(let |const )/g, "var ");
 
-            for (const event of lineEvents) {
-                event(newCmd);
-            }
-        });
+                for (const event of lineEvents) {
+                    event(newCmd);
+                }
+            }, "testplane:repl"),
+        );
     };
 
     const broadcastMessage = (message: string, sockets: net.Socket[]): void => {

--- a/test/src/browser/commands/switchToRepl.ts
+++ b/test/src/browser/commands/switchToRepl.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import repl, { type REPLServer } from "node:repl";
 import net from "node:net";
 import { PassThrough } from "node:stream";
@@ -288,6 +289,25 @@ describe('"switchToRepl" command', () => {
 
             assert.calledOnce(replStart);
             assert.calledOnceWith(warnStub, chalk.yellow("Testplane is already in REPL mode"));
+        });
+
+        it("should evaluate commands in the async context in which repl was started", async () => {
+            const context = new AsyncLocalStorage<string>();
+            const session = mkSessionStub_();
+            const onLine = sandbox.spy(() => context.getStore());
+
+            replServer.on("line", onLine);
+            await initBrowser_({ session });
+
+            const promise = context.run("test-context", () => session.switchToRepl());
+
+            await waitForReplStart_();
+            replServer.emit("line", "getBrowser()");
+            replServer.emit("exit");
+            await promise;
+
+            assert.calledOnceWith(onLine, "getBrowser()");
+            assert.equal(onLine.firstCall.returnValue, "test-context");
         });
 
         ["const", "let"].forEach(decl => {


### PR DESCRIPTION
### What's done?

Some projects use AsyncLocalStorage to store browser object and access it in tests. However, this doesn't work in repl mode, because async context is lost at repl line call site. This PR adds [AsyncResource](https://nodejs.org/api/async_context.html#class-asyncresource) bind method to keep the async context in subsequent calls