### PR TITLE
fix: bring back old browsers support, including ie11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@puppeteer/browsers": "3.0.4",
         "@testplane/wdio-protocols": "9.4.7",
         "@testplane/wdio-utils": "9.5.4",
-        "@testplane/webdriverio": "9.5.28",
+        "@testplane/webdriverio": "9.5.29",
         "@vitest/spy": "2.1.4",
         "buffer-crc32": "1.0.0",
         "chalk": "2.4.2",
@@ -2061,6 +2061,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
       "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -2328,6 +2329,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
       "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+      "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.1"
       },
@@ -3019,9 +3021,10 @@
       }
     },
     "node_modules/@testplane/webdriver": {
-      "version": "9.5.17",
-      "resolved": "https://registry.npmjs.org/@testplane/webdriver/-/webdriver-9.5.17.tgz",
-      "integrity": "sha512-ecmgc4MuLVv+XH49tGDq59TMzSzFkB5yOMOKv5xXDEMKqLwuEssWd1UmHuWYsJwTvIjbDHXto2lvfGrDRKaoPQ==",
+      "version": "9.5.18",
+      "resolved": "https://registry.npmjs.org/@testplane/webdriver/-/webdriver-9.5.18.tgz",
+      "integrity": "sha512-RreVAklCWUD6o4vCDuzHfGwra0FbiJHSe4/8xiJjEv+yxgORmfWHXCiBa1nPWUZHDEmcia2Kyst5ltytLhPJBw==",
+      "license": "MIT",
       "dependencies": {
         "@testplane/wdio-config": "9.5.3",
         "@testplane/wdio-logger": "9.4.6",
@@ -3065,6 +3068,7 @@
       "version": "9.5.3",
       "resolved": "https://registry.npmjs.org/@testplane/wdio-config/-/wdio-config-9.5.3.tgz",
       "integrity": "sha512-329lufaem6vxLq5Govv9lRzue1o2571HsFhI5TpiSH3C1x3SxQ2kQokCN2nGMS4IIEbSPjRQDuKNUuSWhS4hVA==",
+      "license": "MIT",
       "dependencies": {
         "@testplane/wdio-logger": "9.4.6",
         "@testplane/wdio-types": "9.5.2",
@@ -3081,6 +3085,7 @@
       "version": "9.5.2",
       "resolved": "https://registry.npmjs.org/@testplane/wdio-types/-/wdio-types-9.5.2.tgz",
       "integrity": "sha512-D7ge7qJmcR2CG39YBlZ8lZRSeM/yOeBmQXsFxE0LlKurG3h+pEVWiuLhFW6ow2lZvR2jR2tHXI16IRvpXz3BKQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -3106,12 +3111,14 @@
     "node_modules/@testplane/webdriver/node_modules/@testplane/wdio-protocols": {
       "version": "9.4.6",
       "resolved": "https://registry.npmjs.org/@testplane/wdio-protocols/-/wdio-protocols-9.4.6.tgz",
-      "integrity": "sha512-r++AmapEhXpShtNsYbqhX71iZSyUp7YyZV+RoamWVyvgP3ljpeU9cLksz2imyZJ5fCas1qcx9xElPKHRF/zcxw=="
+      "integrity": "sha512-r++AmapEhXpShtNsYbqhX71iZSyUp7YyZV+RoamWVyvgP3ljpeU9cLksz2imyZJ5fCas1qcx9xElPKHRF/zcxw==",
+      "license": "MIT"
     },
     "node_modules/@testplane/webdriver/node_modules/@testplane/wdio-utils": {
       "version": "9.5.3",
       "resolved": "https://registry.npmjs.org/@testplane/wdio-utils/-/wdio-utils-9.5.3.tgz",
       "integrity": "sha512-xZQqXn3ga1aY1JTTnF137lT6Evmn7Dtxs6TSlSEAG3dY+eLIZNz7n0tLNG49BYZY3l8F2k+0TdU6SZ0p28L7qA==",
+      "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^2.2.0",
         "@testplane/edgedriver": "^6.1.4",
@@ -3135,6 +3142,7 @@
       "version": "9.5.2",
       "resolved": "https://registry.npmjs.org/@testplane/wdio-types/-/wdio-types-9.5.2.tgz",
       "integrity": "sha512-D7ge7qJmcR2CG39YBlZ8lZRSeM/yOeBmQXsFxE0LlKurG3h+pEVWiuLhFW6ow2lZvR2jR2tHXI16IRvpXz3BKQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0"
       },
@@ -3143,18 +3151,19 @@
       }
     },
     "node_modules/@testplane/webdriver/node_modules/@types/node": {
-      "version": "20.19.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
-      "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
     },
     "node_modules/@testplane/webdriver/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3219,6 +3228,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
       "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -3244,6 +3254,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
       "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
@@ -3270,6 +3281,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -3298,6 +3310,7 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
       },
@@ -3413,9 +3426,9 @@
       }
     },
     "node_modules/@testplane/webdriverio": {
-      "version": "9.5.28",
-      "resolved": "https://registry.npmjs.org/@testplane/webdriverio/-/webdriverio-9.5.28.tgz",
-      "integrity": "sha512-UWkAOFhhL5DYquwDsr0JnjD5TMC0/drlrUJFWHz6t+s9y8el5z0B+5WJX6xsrjn3q4HyqMCpALNTFZLJCNqj0Q==",
+      "version": "9.5.29",
+      "resolved": "https://registry.npmjs.org/@testplane/webdriverio/-/webdriverio-9.5.29.tgz",
+      "integrity": "sha512-v3jhroYFPSxa6FkohFOVfpfDyw1cGu8uYLb3t8wYqeN2u//m134guWpGZxe8gcFU8/IXpeff9pdfPSCwwitNgg==",
       "license": "MIT",
       "dependencies": {
         "@testplane/wdio-config": "9.5.3",
@@ -3424,7 +3437,7 @@
         "@testplane/wdio-repl": "9.4.4",
         "@testplane/wdio-types": "9.5.5",
         "@testplane/wdio-utils": "9.5.3",
-        "@testplane/webdriver": "9.5.17",
+        "@testplane/webdriver": "9.5.18",
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
         "archiver": "^7.0.1",
@@ -4027,7 +4040,8 @@
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q=="
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "license": "MIT"
     },
     "node_modules/@types/insert-module-globals": {
       "version": "7.0.5",
@@ -4224,6 +4238,7 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -5785,6 +5800,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
       "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       }
@@ -5793,6 +5809,7 @@
       "version": "10.2.14",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
       "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "^4.0.2",
         "get-stream": "^6.0.1",
@@ -5810,6 +5827,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -7574,6 +7592,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -7588,6 +7607,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -7636,6 +7656,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -9339,6 +9360,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
       "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14.17"
       }
@@ -9897,6 +9919,7 @@
       "version": "12.6.1",
       "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
       "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
+      "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^5.2.0",
         "@szmarczak/http-timer": "^5.0.1",
@@ -9921,6 +9944,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -10263,7 +10287,8 @@
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-codes": {
       "version": "1.0.0",
@@ -10329,6 +10354,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
       "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+      "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
@@ -10341,6 +10367,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -11065,7 +11092,8 @@
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "license": "MIT"
     },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
@@ -11173,6 +11201,7 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -11192,6 +11221,7 @@
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/ky/-/ky-0.33.0.tgz",
       "integrity": "sha512-peKzuOlN/q3Q3jOgi4t0cp6DOgif5rVnmiSIsjsmkiOcdnSjkrKSUqQmRWYCTqjUtR9b3xQQr8aj7KwSW1r49A==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -11491,6 +11521,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
       "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -12034,6 +12065,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
       "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -12548,6 +12580,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
       "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -12794,6 +12827,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
       "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+      "license": "MIT",
       "engines": {
         "node": ">=12.20"
       }
@@ -14255,7 +14289,8 @@
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "1.0.1",
@@ -14275,6 +14310,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
       "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+      "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^3.0.0"
       },
@@ -16163,6 +16199,7 @@
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.12.0.tgz",
       "integrity": "sha512-d87yk8lqSFUYtR5fTFe2frpkMIrUEz+lgoJmhcL+J3StVl+8fj8ytE4lLnJOTPCE12YbumNGzf4LYsQyusdV5g==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.0"
       }
@@ -19141,9 +19178,9 @@
       }
     },
     "@testplane/webdriver": {
-      "version": "9.5.17",
-      "resolved": "https://registry.npmjs.org/@testplane/webdriver/-/webdriver-9.5.17.tgz",
-      "integrity": "sha512-ecmgc4MuLVv+XH49tGDq59TMzSzFkB5yOMOKv5xXDEMKqLwuEssWd1UmHuWYsJwTvIjbDHXto2lvfGrDRKaoPQ==",
+      "version": "9.5.18",
+      "resolved": "https://registry.npmjs.org/@testplane/webdriver/-/webdriver-9.5.18.tgz",
+      "integrity": "sha512-RreVAklCWUD6o4vCDuzHfGwra0FbiJHSe4/8xiJjEv+yxgORmfWHXCiBa1nPWUZHDEmcia2Kyst5ltytLhPJBw==",
       "requires": {
         "@testplane/wdio-config": "9.5.3",
         "@testplane/wdio-logger": "9.4.6",
@@ -19243,17 +19280,17 @@
           }
         },
         "@types/node": {
-          "version": "20.19.42",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.42.tgz",
-          "integrity": "sha512-5L7SUaFC1RyDraj2yRhyBzHTobyXHmohD100CChNtyPyleoq37Mqab5Gn8XEKI04dfN/oqPdpHk38MgcQWHbZg==",
+          "version": "20.19.43",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+          "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
           "requires": {
             "undici-types": "~6.21.0"
           }
         },
         "brace-expansion": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-          "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+          "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
           "requires": {
             "balanced-match": "^1.0.0"
           }
@@ -19427,9 +19464,9 @@
       }
     },
     "@testplane/webdriverio": {
-      "version": "9.5.28",
-      "resolved": "https://registry.npmjs.org/@testplane/webdriverio/-/webdriverio-9.5.28.tgz",
-      "integrity": "sha512-UWkAOFhhL5DYquwDsr0JnjD5TMC0/drlrUJFWHz6t+s9y8el5z0B+5WJX6xsrjn3q4HyqMCpALNTFZLJCNqj0Q==",
+      "version": "9.5.29",
+      "resolved": "https://registry.npmjs.org/@testplane/webdriverio/-/webdriverio-9.5.29.tgz",
+      "integrity": "sha512-v3jhroYFPSxa6FkohFOVfpfDyw1cGu8uYLb3t8wYqeN2u//m134guWpGZxe8gcFU8/IXpeff9pdfPSCwwitNgg==",
       "requires": {
         "@testplane/wdio-config": "9.5.3",
         "@testplane/wdio-logger": "9.4.6",
@@ -19437,7 +19474,7 @@
         "@testplane/wdio-repl": "9.4.4",
         "@testplane/wdio-types": "9.5.5",
         "@testplane/wdio-utils": "9.5.3",
-        "@testplane/webdriver": "9.5.17",
+        "@testplane/webdriver": "9.5.18",
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
         "archiver": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@puppeteer/browsers": "3.0.4",
     "@testplane/wdio-protocols": "9.4.7",
     "@testplane/wdio-utils": "9.5.4",
-    "@testplane/webdriverio": "9.5.28",
+    "@testplane/webdriverio": "9.5.29",
     "@vitest/spy": "2.1.4",
     "buffer-crc32": "1.0.0",
     "chalk": "2.4.2",

--- a/src/browser/client-scripts/screen-shooter/operations.ts
+++ b/src/browser/client-scripts/screen-shooter/operations.ts
@@ -45,7 +45,7 @@ import { parseCaptureTarget, PseudoElementSelector } from "./utils/pseudo-elemen
 import { isSafariMobile } from "./utils/user-agent";
 
 export function computeScrollOffset(element: Element): Coord<"page", "css", "y"> {
-    return (isRootLikeElement(element) ? window.scrollY : element.scrollTop) as Coord<"page", "css", "y">;
+    return (isRootLikeElement(element) ? window.pageYOffset : element.scrollTop) as Coord<"page", "css", "y">;
 }
 
 export function computeViewportSize(): Size<"css"> {
@@ -67,8 +67,8 @@ export function computeViewportSize(): Size<"css"> {
 
 export function computeViewportOffset(): Point<"page", "css"> {
     return {
-        left: window.scrollX as Coord<"page", "css", "x">,
-        top: window.scrollY as Coord<"page", "css", "y">
+        left: window.pageXOffset as Coord<"page", "css", "x">,
+        top: window.pageYOffset as Coord<"page", "css", "y">
     };
 }
 
@@ -283,11 +283,11 @@ export function computeSafeArea(
     for (let idx = 0; idx < allElements.length; idx++) {
         const el = allElements[idx];
 
-        if (scrollEl === el || el.contains(scrollEl)) {
+        if (scrollEl === el || lib.contains(el, scrollEl)) {
             continue;
         }
 
-        if (singleCaptureElement && (el === singleCaptureElement || el.contains(singleCaptureElement))) {
+        if (singleCaptureElement && (el === singleCaptureElement || lib.contains(el, singleCaptureElement))) {
             continue;
         }
 
@@ -318,20 +318,20 @@ export function computeSafeArea(
         const fixedPositionedParent = findFixedPositionedParent(el);
         const isInsideScrollContextFixedParent =
             fixedPositionedParent !== null &&
-            (fixedPositionedParent === scrollEl || fixedPositionedParent.contains(scrollEl));
+            (fixedPositionedParent === scrollEl || lib.contains(fixedPositionedParent, scrollEl));
 
         if (position === "fixed" || (fixedPositionedParent && !isInsideScrollContextFixedParent)) {
             likelyInterferes = true;
             // If the fixed element is inside a capture element, it's almost certainly interfering
-            shouldSkipZIndexCheck = captureElements.some(capEl => capEl.contains(el));
+            shouldSkipZIndexCheck = captureElements.some(capEl => lib.contains(capEl, el));
         } else if (position === "absolute") {
             // Skip absolutely positioned elements that are inside capture elements
-            if (captureElements.some(capEl => capEl.contains(el))) continue;
+            if (captureElements.some(capEl => lib.contains(capEl, el))) continue;
 
             // Absolute elements interfere only if positioned relative to ancestor outside scroll container
             const containingBlock = findContainingBlock(el);
             // scrollElem may be window, in which case it doesn't have a contains method
-            if (scrollEl !== document.documentElement && !scrollEl.contains(containingBlock)) {
+            if (scrollEl !== document.documentElement && !lib.contains(scrollEl, containingBlock)) {
                 likelyInterferes = true;
             }
         } else if (position === "sticky") {
@@ -344,7 +344,7 @@ export function computeSafeArea(
             const scrollParentBcr = scrollParent.getBoundingClientRect();
             topValue += isRootLikeElement(scrollParent) ? 0 : scrollParentBcr.top;
             shouldSkipZIndexCheck =
-                captureElements.some(capEl => capEl === el || capEl.contains(el)) &&
+                captureElements.some(capEl => capEl === el || lib.contains(capEl, el)) &&
                 (scrollParent === scrollEl || (isRootLikeElement(scrollParent) && isRootLikeElement(scrollEl)));
 
             if (!isNaN(topValue)) {
@@ -598,8 +598,8 @@ function saveElementScrollPosition(element: Element): void {
     const savedPosition: ElementScrollPosition = isRootLikeElement(element)
         ? {
               element,
-              left: window.scrollX,
-              top: window.scrollY
+              left: window.pageXOffset,
+              top: window.pageYOffset
           }
         : {
               element,

--- a/src/browser/client-scripts/screen-shooter/types.ts
+++ b/src/browser/client-scripts/screen-shooter/types.ts
@@ -60,7 +60,7 @@ export interface PrepareScreenshotSuccess {
     captureSpecs: CaptureSpec<"viewport", "device">[];
     // Viewport size
     viewportSize: Size<"device">;
-    // Viewport scroll offsets, window.scrollX / window.scrollY respectively
+    // Viewport scroll offsets, window.pageXOffset / window.pageYOffset respectively
     viewportOffset: Point<"page", "device">;
     // Total height of the document, may be larger than viewport
     documentSize: Size<"device">;

--- a/src/browser/client-scripts/screen-shooter/utils/clip-rect.ts
+++ b/src/browser/client-scripts/screen-shooter/utils/clip-rect.ts
@@ -1,4 +1,5 @@
 import { Rect, Coord, Length, getIntersection } from "@isomorphic";
+import * as lib from "@lib";
 import { getBoundingClientContentRect } from "./element-rect";
 import { isRootLikeElement } from "./scroll";
 import { findContainingBlock } from "./dom";
@@ -63,18 +64,18 @@ function escapesOverflowClippingViaAbsoluteContainingBlocks(
     absoluteContainingBlocks: AbsoluteContainingBlock[]
 ): boolean {
     return absoluteContainingBlocks.some(({ absoluteAncestor, containingBlock }) => {
-        if (absoluteAncestor === clippingElement || !clippingElement.contains(absoluteAncestor)) {
+        if (absoluteAncestor === clippingElement || !lib.contains(clippingElement, absoluteAncestor)) {
             return false;
         }
 
-        return containingBlock !== clippingElement && containingBlock.contains(clippingElement);
+        return containingBlock !== clippingElement && lib.contains(containingBlock, clippingElement);
     });
 }
 
 /** Fixed-position descendants escape clipping of ancestors above the fixed ancestor */
 function escapesOverflowClippingViaFixedAncestors(clippingElement: Element, fixedAncestors: Element[]): boolean {
     return fixedAncestors.some(
-        fixedAncestor => fixedAncestor !== clippingElement && clippingElement.contains(fixedAncestor)
+        fixedAncestor => fixedAncestor !== clippingElement && lib.contains(clippingElement, fixedAncestor)
     );
 }
 

--- a/src/browser/client-scripts/screen-shooter/utils/dom.ts
+++ b/src/browser/client-scripts/screen-shooter/utils/dom.ts
@@ -58,10 +58,10 @@ export function forEachRoot(cb: (root: Element | ShadowRoot) => void): void {
 }
 
 export function getParentElement(node: Node): Element | null {
-    if (node instanceof ShadowRoot) return node.host;
+    if (lib.isShadowRoot(node)) return node.host;
     if (node instanceof Element) {
         const root = lib.getRootNode(node);
-        return node.parentElement || (root instanceof ShadowRoot ? root.host : null);
+        return node.parentElement || (lib.isShadowRoot(root) ? root.host : null);
     }
     return node.parentNode instanceof Element ? node.parentNode : null;
 }

--- a/src/browser/client-scripts/screen-shooter/utils/scroll.ts
+++ b/src/browser/client-scripts/screen-shooter/utils/scroll.ts
@@ -85,7 +85,7 @@ export function getCommonScrollParent(targets: ElementTarget[]): Element {
 }
 
 function getElementScrollTop(element: Element): number {
-    return isRootLikeElement(element) ? window.scrollY : element.scrollTop;
+    return isRootLikeElement(element) ? window.pageYOffset : element.scrollTop;
 }
 
 const SCROLL_APPLY_MAX_WAIT_MS = 50;
@@ -112,8 +112,8 @@ export function performScrollFixForSafariIfNeeded(targetY: number): void {
     if (!isSafariMobile()) {
         return;
     }
-    if (window.scrollY < 100 && targetY < 100) {
-        window.scrollTo(window.scrollX, 100);
+    if (window.pageYOffset < 100 && targetY < 100) {
+        window.scrollTo(window.pageXOffset, 100);
     }
 }
 
@@ -125,17 +125,17 @@ export function scrollElementBy(
     const delta = deltaY;
     const isRootLike = isRootLikeElement(element);
     const scrollMetricsElement = isRootLike ? getPageScrollElement() : element;
-    const currentScrollY = isRootLike ? window.scrollY : element.scrollTop;
+    const currentScrollY = isRootLike ? window.pageYOffset : element.scrollTop;
 
     // Clamping is needed due to a bug in safari - https://bugs.webkit.org/show_bug.cgi?id=179735
     const maxScrollY = scrollMetricsElement.scrollHeight - scrollMetricsElement.clientHeight;
     const targetY = Math.max(0, Math.min(currentScrollY + delta, maxScrollY));
 
     if (isRootLike) {
-        logger?.("scrollElementBy: scrolling window.scrollTo(" + window.scrollX + ", " + targetY + ")");
+        logger?.("scrollElementBy: scrolling window.scrollTo(" + window.pageXOffset + ", " + targetY + ")");
 
         performScrollFixForSafariIfNeeded(targetY);
-        window.scrollTo(window.scrollX, targetY);
+        window.scrollTo(window.pageXOffset, targetY);
     } else {
         logger?.("scrollElementBy: scrolling element.scrollTo(" + element.scrollLeft + ", " + targetY + ")");
         element.scrollTo(element.scrollLeft, targetY);
@@ -154,7 +154,7 @@ export function scrollElementBy(
 export function scrollElementToOffset(element: Element, offset: Coord<"page", "css", "y">): void {
     const isRootLike = isRootLikeElement(element);
     const scrollMetricsElement = isRootLike ? getPageScrollElement() : element;
-    const currentScrollY = isRootLike ? window.scrollY : element.scrollTop;
+    const currentScrollY = isRootLike ? window.pageYOffset : element.scrollTop;
 
     // Clamping is needed due to a bug in safari - https://bugs.webkit.org/show_bug.cgi?id=179735
     const maxScrollY = scrollMetricsElement.scrollHeight - scrollMetricsElement.clientHeight;
@@ -162,7 +162,7 @@ export function scrollElementToOffset(element: Element, offset: Coord<"page", "c
 
     if (isRootLike) {
         performScrollFixForSafariIfNeeded(targetY);
-        window.scrollTo(window.scrollX, targetY);
+        window.scrollTo(window.pageXOffset, targetY);
     } else {
         element.scrollTo(element.scrollLeft, targetY);
     }

--- a/src/browser/client-scripts/screen-shooter/utils/z-index.ts
+++ b/src/browser/client-scripts/screen-shooter/utils/z-index.ts
@@ -1,3 +1,4 @@
+import * as lib from "@lib";
 import { getParentElement } from "./dom";
 
 function getCssProp(style: CSSStyleDeclaration, prop: string): string | undefined {
@@ -83,7 +84,7 @@ function getClosestStackingContext(node: Node | null): Element {
         return document.documentElement;
     }
 
-    if (node instanceof ShadowRoot) {
+    if (lib.isShadowRoot(node)) {
         return getClosestStackingContext(node.host);
     }
 

--- a/src/browser/client-scripts/shared/lib.compat.ts
+++ b/src/browser/client-scripts/shared/lib.compat.ts
@@ -41,5 +41,23 @@ export function getRootNode(node: Node): Node {
     return root;
 }
 
+export function isShadowRoot(node: Node): node is ShadowRoot {
+    return typeof ShadowRoot !== "undefined" && node instanceof ShadowRoot;
+}
+
+export function contains(parent: Node, node: Node): boolean {
+    if (typeof parent.contains === "function") {
+        return parent.contains(node);
+    }
+
+    for (let current: Node | null = node; current; current = current.parentNode) {
+        if (current === parent) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 export { getComputedStyle } from "./polyfills/getComputedStyle";
 export { matchMedia } from "./polyfills/matchMedia";

--- a/src/browser/client-scripts/shared/lib.native.ts
+++ b/src/browser/client-scripts/shared/lib.native.ts
@@ -37,3 +37,11 @@ export function trim(str: string): string {
 export function getRootNode(node: Node): Node {
     return node.getRootNode();
 }
+
+export function isShadowRoot(node: Node): node is ShadowRoot {
+    return node instanceof ShadowRoot;
+}
+
+export function contains(parent: Node, node: Node): boolean {
+    return parent.contains(node);
+}

--- a/src/browser/commands/waitForStaticToLoad.ts
+++ b/src/browser/commands/waitForStaticToLoad.ts
@@ -21,7 +21,7 @@ function browserIsPageReady(): { ready: boolean; reason?: string; pendingResourc
         var image = document.images.item(i);
 
         if (image && !image.complete) {
-            return { ready: false, reason: `Image from ${image.src} is loading` };
+            return { ready: false, reason: "Image from " + image.src + " is loading" };
         }
     }
 
@@ -31,75 +31,101 @@ function browserIsPageReady(): { ready: boolean; reason?: string; pendingResourc
     for (var i = 0; i < externalStylesCount; i++) {
         var style = externalStyles.item(i);
 
-        if (!style.sheet) {
-            return { ready: false, reason: `Styles from ${style.href} are loading` };
+        if (style && !style.sheet) {
+            return { ready: false, reason: "Styles from " + style.href + " are loading" };
         }
     }
 
-    var waitingForResourceUrls = new Set<string>();
+    var waitingForResourceUrls = Object.create(null) as Record<string, true>;
 
     var nodesWithInlineStylesWithUrl = document.querySelectorAll<HTMLElement>('[style*="url("]');
-    var styleWithUrlRegExp = /^url\("(.*)"\)$/;
+    var styleWithUrlRegExp = /^url\((?:"(.*)"|'(.*)')\)$/;
 
-    for (var node of nodesWithInlineStylesWithUrl) {
-        if (!node.clientHeight || !node.clientWidth) {
+    for (var nodeIndex = 0; nodeIndex < nodesWithInlineStylesWithUrl.length; nodeIndex++) {
+        var node = nodesWithInlineStylesWithUrl.item(nodeIndex);
+
+        if (!node || !node.clientHeight || !node.clientWidth) {
             continue;
         }
 
         var inlineRulesCount = node.style ? node.style.length : 0;
 
         for (var i = 0; i < inlineRulesCount; i++) {
-            var inlineRuleName = node.style[i];
+            var inlineRuleName = node.style.item(i);
             var inlineRuleValue = node.style[inlineRuleName as keyof CSSStyleDeclaration] as string;
 
-            if (!inlineRuleValue || (!inlineRuleValue.startsWith('url("') && !inlineRuleValue.startsWith("url('"))) {
+            if (
+                !inlineRuleValue ||
+                (inlineRuleValue.indexOf('url("') !== 0 && inlineRuleValue.indexOf("url('") !== 0)
+            ) {
                 continue;
             }
 
             var computedStyleValue = getComputedStyle(node).getPropertyValue(inlineRuleName);
             var match = styleWithUrlRegExp.exec(computedStyleValue);
+            var resourceUrl = match && (match[1] || match[2]);
 
-            if (match && match[1] && !match[1].startsWith("data:")) {
-                waitingForResourceUrls.add(match[1]);
+            if (resourceUrl && resourceUrl.indexOf("data:") !== 0) {
+                waitingForResourceUrls[resourceUrl] = true;
             }
         }
     }
 
-    for (var styleSheet of document.styleSheets) {
+    var styleSheetsCount = (document.styleSheets && document.styleSheets.length) || 0;
+
+    for (var styleSheetIndex = 0; styleSheetIndex < styleSheetsCount; styleSheetIndex++) {
+        var styleSheet = document.styleSheets.item(styleSheetIndex);
+
+        if (!styleSheet) {
+            continue;
+        }
+
         try {
-            for (var cssRules of styleSheet.cssRules) {
-                var cssStyleRule = cssRules as CSSStyleRule;
+            var cssRules = styleSheet.cssRules;
+            var cssRulesCount = (cssRules && cssRules.length) || 0;
+
+            for (var cssRuleIndex = 0; cssRuleIndex < cssRulesCount; cssRuleIndex++) {
+                var cssStyleRule = cssRules.item(cssRuleIndex) as CSSStyleRule;
                 var cssStyleSelector = cssStyleRule.selectorText;
                 var cssStyleRulesCount = cssStyleRule.style ? cssStyleRule.style.length : 0;
 
                 var displayedNodeElementsStyles: CSSStyleDeclaration[] | null = null;
 
                 for (var i = 0; i < cssStyleRulesCount; i++) {
-                    var cssRuleName = cssStyleRule.style[i];
+                    var cssRuleName = cssStyleRule.style.item(i);
                     var cssRuleValue = cssStyleRule.style[cssRuleName as keyof CSSStyleDeclaration] as string;
 
-                    if (!cssRuleValue || (!cssRuleValue.startsWith('url("') && !cssRuleValue.startsWith("url('"))) {
+                    if (!cssRuleValue || (cssRuleValue.indexOf('url("') !== 0 && cssRuleValue.indexOf("url('") !== 0)) {
                         continue;
                     }
 
                     if (!displayedNodeElementsStyles) {
                         displayedNodeElementsStyles = [] as CSSStyleDeclaration[];
+                        var matchingNodes = document.querySelectorAll<HTMLElement>(cssStyleSelector);
 
-                        document.querySelectorAll<HTMLElement>(cssStyleSelector).forEach(function (node) {
-                            if (!node.clientHeight || !node.clientWidth) {
-                                return;
+                        for (var matchingNodeIndex = 0; matchingNodeIndex < matchingNodes.length; matchingNodeIndex++) {
+                            var matchingNode = matchingNodes.item(matchingNodeIndex);
+
+                            if (!matchingNode || !matchingNode.clientHeight || !matchingNode.clientWidth) {
+                                continue;
                             }
 
-                            (displayedNodeElementsStyles as CSSStyleDeclaration[]).push(getComputedStyle(node));
-                        });
+                            displayedNodeElementsStyles.push(getComputedStyle(matchingNode));
+                        }
                     }
 
-                    for (var nodeStyles of displayedNodeElementsStyles) {
+                    for (
+                        var nodeStylesIndex = 0;
+                        nodeStylesIndex < displayedNodeElementsStyles.length;
+                        nodeStylesIndex++
+                    ) {
+                        var nodeStyles = displayedNodeElementsStyles[nodeStylesIndex];
                         var computedStyleValue = nodeStyles.getPropertyValue(cssRuleName);
                         var match = styleWithUrlRegExp.exec(computedStyleValue);
+                        var resourceUrl = match && (match[1] || match[2]);
 
-                        if (match && match[1] && !match[1].startsWith("data:")) {
-                            waitingForResourceUrls.add(match[1]);
+                        if (resourceUrl && resourceUrl.indexOf("data:") !== 0) {
+                            waitingForResourceUrls[resourceUrl] = true;
                         }
                     }
                 }
@@ -107,30 +133,41 @@ function browserIsPageReady(): { ready: boolean; reason?: string; pendingResourc
         } catch (err) {} // eslint-disable-line no-empty
     }
 
-    var performanceResourceEntries = performance.getEntriesByType("resource") as PerformanceResourceTiming[];
+    var performanceResourceEntries =
+        window.performance && typeof window.performance.getEntriesByType === "function"
+            ? (window.performance.getEntriesByType("resource") as PerformanceResourceTiming[])
+            : [];
 
     performanceResourceEntries.forEach(function (performanceResourceEntry) {
-        waitingForResourceUrls.delete(performanceResourceEntry.name);
+        delete waitingForResourceUrls[performanceResourceEntry.name];
     });
 
-    if (!waitingForResourceUrls.size) {
+    var pendingResources = Object.keys(waitingForResourceUrls);
+
+    if (!pendingResources.length) {
         return { ready: true };
     }
 
-    var pendingResources = Array.from(waitingForResourceUrls);
-
-    return { ready: false, reason: "Resources are not loaded", pendingResources };
+    return { ready: false, reason: "Resources are not loaded", pendingResources: pendingResources };
 }
 
 function browserAreResourcesLoaded(pendingResources: string[]): string[] {
-    var pendingResourcesSet = new Set(pendingResources);
-    var performanceResourceEntries = performance.getEntriesByType("resource") as PerformanceResourceTiming[];
+    var pendingResourcesMap = Object.create(null) as Record<string, true>;
+
+    for (var i = 0; i < pendingResources.length; i++) {
+        pendingResourcesMap[pendingResources[i]] = true;
+    }
+
+    var performanceResourceEntries =
+        window.performance && typeof window.performance.getEntriesByType === "function"
+            ? (window.performance.getEntriesByType("resource") as PerformanceResourceTiming[])
+            : [];
 
     performanceResourceEntries.forEach(function (performanceResourceEntry) {
-        pendingResourcesSet.delete(performanceResourceEntry.name);
+        delete pendingResourcesMap[performanceResourceEntry.name];
     });
 
-    return Array.from(pendingResourcesSet);
+    return Object.keys(pendingResourcesMap);
 }
 /* eslint-enable no-var */
 

--- a/src/browser/history/rrweb.ts
+++ b/src/browser/history/rrweb.ts
@@ -15,6 +15,10 @@ const debug = makeDebug("testplane:time-travel:rrweb");
 const rrwebCode = fs.readFileSync(path.join(__dirname, "../client-scripts/rrweb-record.min.js"), "utf-8");
 const sessionsWithRrwebSent = new WeakSet<WebdriverIO.Browser>();
 const sessionsWithUnsupportedRrweb = new WeakSet<WebdriverIO.Browser>();
+const INTERNET_EXPLORER_BROWSER_NAME = "internet explorer";
+
+const isInternetExplorer = (session: WebdriverIO.Browser): boolean =>
+    session.capabilities.browserName?.toLowerCase() === INTERNET_EXPLORER_BROWSER_NAME;
 
 interface CollectRrwebEventsResult {
     isRrwebSupported?: false;
@@ -28,6 +32,10 @@ export async function installRrwebAndCollectEvents(
     session: WebdriverIO.Browser,
     callstack: Callstack,
 ): Promise<eventWithTime[]> {
+    if (isInternetExplorer(session)) {
+        return [];
+    }
+
     return runWithoutHistory<Promise<eventWithTime[]>>({ callstack }, async () => {
         if (sessionsWithUnsupportedRrweb.has(session)) {
             return [];
@@ -74,6 +82,10 @@ export async function installRrwebAndCollectEvents(
 }
 
 export async function cleanupRrweb(session: WebdriverIO.Browser, callstack: Callstack): Promise<void> {
+    if (isInternetExplorer(session)) {
+        return;
+    }
+
     try {
         await runWithoutHistory<Promise<void>>({ callstack }, () =>
             session.execute(() => {

--- a/src/browser/new-browser.ts
+++ b/src/browser/new-browser.ts
@@ -25,6 +25,8 @@ export type HeadlessBrowserOptions = Partial<
     >
 >;
 const DEFAULT_PORT = 4444;
+const INTERNET_EXPLORER_BROWSER_NAME = "internet explorer";
+const WEBDRIVER_CLASSIC_CAPABILITY = "wdio:enforceWebDriverClassic";
 
 const headlessBrowserOptions: HeadlessBrowserOptions = {
     [BrowserName.CHROME]: {
@@ -216,11 +218,15 @@ export class NewBrowser extends Browser {
     }
 
     protected _addWebDriverClassicCapability(capabilities: WebdriverIO.Capabilities): WebdriverIO.Capabilities {
-        if (capabilities?.webSocketUrl || "wdio:enforceWebDriverClassic" in capabilities) {
+        if (
+            capabilities.browserName?.toLowerCase() === INTERNET_EXPLORER_BROWSER_NAME ||
+            capabilities?.webSocketUrl ||
+            WEBDRIVER_CLASSIC_CAPABILITY in capabilities
+        ) {
             return capabilities;
         }
 
-        return assign({}, capabilities, { "wdio:enforceWebDriverClassic": true });
+        return assign({}, capabilities, { [WEBDRIVER_CLASSIC_CAPABILITY]: true });
     }
 
     protected _extendCapabilitiesByVersion(): WebdriverIO.Capabilities {

--- a/test/src/browser/history/rrweb.js
+++ b/test/src/browser/history/rrweb.js
@@ -1,0 +1,33 @@
+"use strict";
+
+const { cleanupRrweb, installRrwebAndCollectEvents } = require("src/browser/history/rrweb");
+
+describe("browser/history/rrweb", () => {
+    const sandbox = sinon.createSandbox();
+
+    afterEach(() => sandbox.restore());
+
+    describe("internet explorer", () => {
+        let session;
+
+        beforeEach(() => {
+            session = {
+                capabilities: { browserName: "internet explorer" },
+                execute: sandbox.stub(),
+            };
+        });
+
+        it("should not install rrweb", async () => {
+            const events = await installRrwebAndCollectEvents(session, {});
+
+            assert.deepEqual(events, []);
+            assert.notCalled(session.execute);
+        });
+
+        it("should not clean up rrweb", async () => {
+            await cleanupRrweb(session, {});
+
+            assert.notCalled(session.execute);
+        });
+    });
+});


### PR DESCRIPTION
### What's done?

⚠️ Important: this PR relies on https://github.com/gemini-testing/webdriverio/pull/45

- Do not add enforce webdriver classic custom capabilitiy, because that breaks session creation on IE
- Migrate to IE-friendly APIs in assertView logic

### How I tested?

Used this browser config:

```
'ie-11': {
    isolation: false,
    calibrate: true,
    sessionRequestTimeout: 180000,
    windowSize: '1920x1080',
    desiredCapabilities: {
        browserName: "internet explorer",
        browserVersion: "11",
    },
},
```

With a minimal test:
```
    it("should capture a screenshot with assertView", async ({browser}) => {
        await browser.url('https://ya.ru');
        await browser.assertView("testing", ".headline");
    });
```

Results:

<img width="1199" height="353" alt="Screenshot 2026-07-19 at 11 47 45 PM" src="https://github.com/user-attachments/assets/268f5d82-a819-41b1-b122-404d0b299631" />
