### PR TITLE
fix: bring page to front when isolation is turned on

### DIFF
--- a/src/browser/cdp/domains/target.ts
+++ b/src/browser/cdp/domains/target.ts
@@ -107,7 +107,7 @@ export class CDPTarget extends CDPEventEmitter<TargetEvents> {
     }
 
     /** @link https://chromedevtools.github.io/devtools-protocol/1-3/Target/#method-detachFromTarget */
-    async detachFromTarget(sessionId: CDPSessionId): Promise<AttachToTargetResponse["sessionId"]> {
+    async detachFromTarget(sessionId: CDPSessionId): Promise<void> {
         return this._connection.request("Target.detachFromTarget", { params: { sessionId } });
     }
 

--- a/src/browser/existing-browser.ts
+++ b/src/browser/existing-browser.ts
@@ -419,7 +419,11 @@ export class ExistingBrowser extends Browser {
         const { sessionId } = await cdpTarget.attachToTarget(incognitoWindowId);
         // Important for chrome older than ~133, because otherwise "focus" states on the page will be lost in
         // headful mode, with isolation=true and resetCursor=false.
-        await this._cdp.page.bringToFront(sessionId);
+        try {
+            await this._cdp.page.bringToFront(sessionId);
+        } finally {
+            await cdpTarget.detachFromTarget(sessionId).catch(() => {});
+        }
     }
 
     protected async _performIsolation({

--- a/src/browser/existing-browser.ts
+++ b/src/browser/existing-browser.ts
@@ -415,6 +415,11 @@ export class ExistingBrowser extends Browser {
             ...browserContextIdsToClose.map(contextId => cdpTarget.disposeBrowserContext(contextId)),
             ...currentTargets.map(target => cdpTarget.closeTarget(target.targetId).catch(() => {})),
         ]);
+
+        const { sessionId } = await cdpTarget.attachToTarget(incognitoWindowId);
+        // Important for chrome older than ~133, because otherwise "focus" states on the page will be lost in
+        // headful mode, with isolation=true and resetCursor=false.
+        await this._cdp.page.bringToFront(sessionId);
     }
 
     protected async _performIsolation({

--- a/test/src/browser/existing-browser.js
+++ b/test/src/browser/existing-browser.js
@@ -61,8 +61,11 @@ describe("ExistingBrowser", () => {
                 createTarget: sandbox.stub().resolves({ targetId: "some-target-id" }),
                 closeTarget: sandbox.stub().resolves(),
                 activateTarget: sandbox.stub().resolves(),
-                attachToTarget: sandbox.stub().resolves("some-target-id"),
+                attachToTarget: sandbox.stub().resolves({ sessionId: "some-session-id" }),
                 getTargets: sandbox.stub().resolves({ targetInfos: [] }),
+            },
+            page: {
+                bringToFront: sandbox.stub().resolves(),
             },
             close: sandbox.stub(),
         };
@@ -586,6 +589,22 @@ describe("ExistingBrowser", () => {
                 await initBrowser_(mkBrowser_({ isolation: true }), { sessionCaps });
 
                 assert.calledOnceWithExactly(CDPStub.target.createTarget, { browserContextId: "new-browser-context" });
+            });
+
+            it("should bring new page to front", async () => {
+                CDPStub.target.createTarget.resolves({ targetId: "new-target-id" });
+                CDPStub.target.attachToTarget.resolves({ sessionId: "new-session-id" });
+                const sessionCaps = { browserName: "chrome", browserVersion: "100.0" };
+
+                await initBrowser_(mkBrowser_({ isolation: true }), { sessionCaps });
+
+                assert.calledOnceWithExactly(CDPStub.target.attachToTarget, "new-target-id");
+                assert.calledOnceWithExactly(CDPStub.page.bringToFront, "new-session-id");
+                assert.callOrder(
+                    CDPStub.target.activateTarget,
+                    CDPStub.target.attachToTarget,
+                    CDPStub.page.bringToFront,
+                );
             });
 
             it("should work with chrome-headless-shell", async () => {

--- a/test/src/browser/existing-browser.js
+++ b/test/src/browser/existing-browser.js
@@ -62,6 +62,7 @@ describe("ExistingBrowser", () => {
                 closeTarget: sandbox.stub().resolves(),
                 activateTarget: sandbox.stub().resolves(),
                 attachToTarget: sandbox.stub().resolves({ sessionId: "some-session-id" }),
+                detachFromTarget: sandbox.stub().resolves(),
                 getTargets: sandbox.stub().resolves({ targetInfos: [] }),
             },
             page: {
@@ -600,11 +601,26 @@ describe("ExistingBrowser", () => {
 
                 assert.calledOnceWithExactly(CDPStub.target.attachToTarget, "new-target-id");
                 assert.calledOnceWithExactly(CDPStub.page.bringToFront, "new-session-id");
+                assert.calledOnceWithExactly(CDPStub.target.detachFromTarget, "new-session-id");
                 assert.callOrder(
                     CDPStub.target.activateTarget,
                     CDPStub.target.attachToTarget,
                     CDPStub.page.bringToFront,
+                    CDPStub.target.detachFromTarget,
                 );
+            });
+
+            it("should detach from new page if bringing it to front fails", async () => {
+                CDPStub.target.attachToTarget.resolves({ sessionId: "new-session-id" });
+                CDPStub.page.bringToFront.rejects(new Error("bring to front failed"));
+                const sessionCaps = { browserName: "chrome", browserVersion: "100.0" };
+
+                await assert.isRejected(
+                    initBrowser_(mkBrowser_({ isolation: true }), { sessionCaps }),
+                    "bring to front failed",
+                );
+
+                assert.calledOnceWithExactly(CDPStub.target.detachFromTarget, "new-session-id");
             });
 
             it("should work with chrome-headless-shell", async () => {


### PR DESCRIPTION
### What's done?

Context:
- Isolation works by creating new browsing context, essentially meaning creating a new tab or window
- When we perform isolation on older browsers, the window becomes not focused until the next iteration
- This leads to "focus" states on elements to be absent in that window
- We didn't see this issue in Testplane 8, because `resetCursor` was true by default and cursor reset brings the window into focus
- On Testplane 9, `resetCursor` is false by default and this issue became apparent
- Interestingly, this issue won't reproduce on newer browsers like Chrome 144. Supposedly, due to this commit: https://chromium.googlesource.com/chromium/src/+/b5c6f8ac5bb0947e3b772b32350132dfa6426847 that changes the way session window works.

### How I tested?

Reproduced the issue on the following minimal case:
```
await browser.url("https://nda.ya.ru/t/Hbwgz3kb7jqnAM");

await browser.pause(3000);

await browser.saveScreenshot('screenshot-focus.png');
```

On chrome 123 running with selenoid locally, with `headless=false, resetCursor=false, isolation=true`.

Verified that this issue went away after the fix.