### PR TITLE
fix: correctly handle parents with overflow clipping and display=contents

### DIFF
--- a/src/browser/client-scripts/screen-shooter/utils/clip-rect.ts
+++ b/src/browser/client-scripts/screen-shooter/utils/clip-rect.ts
@@ -102,6 +102,13 @@ export function getClipRect(element: Element, logger?: (...args: unknown[]) => u
         }
         const style = getComputedStyle(current);
 
+        // display: contents elements do not generate a box, so their overflow
+        // declarations cannot establish a clipping area for descendants.
+        if (style.display === "contents") {
+            current = current.parentElement;
+            continue;
+        }
+
         if (hasOverflowClipping(style)) {
             const isEscapingCurrentOverflowClipping =
                 escapesOverflowClippingViaAbsoluteContainingBlocks(current, absoluteContainingBlocks) ||

--- a/test/browser-env/tests/desktop/screenshooter/computeCaptureSpecs.testplane.ts
+++ b/test/browser-env/tests/desktop/screenshooter/computeCaptureSpecs.testplane.ts
@@ -307,6 +307,17 @@ describe("computeCaptureSpecs", () => {
             await browser.assertView("overflow-hidden");
         });
 
+        it("should not clip element by a display:contents ancestor with overflow:hidden", async () => {
+            const { default: html } = await import(
+                "./fixtures/capture-areas/display-contents-overflow-hidden.html?raw"
+            );
+            document.body.innerHTML = html;
+
+            const result = computeCaptureSpecs([".target"]);
+            expect(result).toHaveLength(1);
+            expect(result[0].visible).toEqual(result[0].full);
+        });
+
         it("should clip visible rect to overflow:scroll container", async ({ browser }) => {
             const { default: html } = await import("./fixtures/capture-areas/overflow-scroll.html?raw");
             document.body.innerHTML = html;

--- a/test/browser-env/tests/desktop/screenshooter/fixtures/capture-areas/display-contents-overflow-hidden.html
+++ b/test/browser-env/tests/desktop/screenshooter/fixtures/capture-areas/display-contents-overflow-hidden.html
@@ -1,0 +1,27 @@
+<style>
+    * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+    }
+
+    body {
+        padding: 40px;
+        background: #f0f0f0;
+    }
+
+    .boxless-parent {
+        display: contents;
+        overflow: hidden;
+    }
+
+    .target {
+        width: 240px;
+        height: 120px;
+        background: #e8d44d;
+    }
+</style>
+
+<div class="boxless-parent">
+    <div class="target"></div>
+</div>


### PR DESCRIPTION
### What's done?

Previously parents with overflow: hidden and display: contents still applied their bounding box as clipping area for children. That's incorrect, now we skip such parents when computing clip rects.