### PR TITLE
feat: allow plugins to register additional unhandledRejection filters

### DIFF
--- a/src/unstable.ts
+++ b/src/unstable.ts
@@ -1,2 +1,4 @@
 export { launchBrowser, attachToBrowser } from "./browser/standalone";
 export type { StandaloneBrowserOptions, StandaloneBrowserOptionsInput } from "./browser/standalone/types";
+export { registerUnhandledRejectionFilter } from "./utils/errors";
+export type { UnhandledRejectionFilter } from "./utils/errors";

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,4 +1,38 @@
+import * as logger from "./logger";
+
+export type UnhandledRejectionFilter = (err: Error) => boolean;
+
 const puppeteerErrMsgs = [/Cannot extract value when objectId is given/, /Execution context was destroyed/];
+
+const registeredFilters = new Set<UnhandledRejectionFilter>();
+
+/**
+ * Registers an extra predicate consulted by `shouldIgnoreUnhandledRejection`, alongside the
+ * built-in Puppeteer/CDP noise filter below.
+ *
+ * By default, any unhandled rejection in a worker terminates the whole Testplane run - on
+ * purpose, since it usually means a test is missing an `await` and continuing could produce
+ * silently wrong results. But that blanket policy also catches unrelated, known-safe async
+ * failures that plugins can trigger outside of any actual test - e.g. a plugin that reads a file
+ * purely for its static configuration during test discovery, before any test has started, where
+ * a stray async side effect in that file's import graph has nothing to do with a real test
+ * missing an `await`. This lets a plugin author say "this specific kind of rejection is not a
+ * sign of a real bug" without weakening the default protection for everyone else.
+ *
+ * A filter is only ever asked to *ignore* a rejection - registering one can never make Testplane
+ * treat something as fatal that it wouldn't already. A filter that throws is treated as "did not
+ * match" (fail safe) and logged, so a buggy filter can never itself become a new way to hide a
+ * real error.
+ *
+ * @returns a function that unregisters the filter.
+ */
+export const registerUnhandledRejectionFilter = (filter: UnhandledRejectionFilter): (() => void) => {
+    registeredFilters.add(filter);
+
+    return () => {
+        registeredFilters.delete(filter);
+    };
+};
 
 export const shouldIgnoreUnhandledRejection = (err: Error | undefined): boolean => {
     if (!err) {
@@ -11,6 +45,16 @@ export const shouldIgnoreUnhandledRejection = (err: Error | undefined): boolean 
 
     if (puppeteerErrMsgs.some(msg => msg.test(err.message)) && err.stack?.includes("/puppeteer-core/")) {
         return true;
+    }
+
+    for (const filter of registeredFilters) {
+        try {
+            if (filter(err)) {
+                return true;
+            }
+        } catch (filterError) {
+            logger.warn("A registered unhandled rejection filter threw and was ignored:", filterError);
+        }
     }
 
     return false;

--- a/test/src/utils/errors.ts
+++ b/test/src/utils/errors.ts
@@ -1,0 +1,101 @@
+import { shouldIgnoreUnhandledRejection, registerUnhandledRejectionFilter } from "../../../src/utils/errors";
+
+describe("utils/errors", () => {
+    describe("shouldIgnoreUnhandledRejection", () => {
+        it("should return false if no error is passed", () => {
+            assert.isFalse(shouldIgnoreUnhandledRejection(undefined));
+        });
+
+        it("should ignore known Puppeteer/CDP protocol errors by name", () => {
+            const err = new Error("some message");
+            err.name = "ProtocolError";
+
+            assert.isTrue(shouldIgnoreUnhandledRejection(err));
+        });
+
+        it("should ignore known Puppeteer/CDP target-closed errors by name", () => {
+            const err = new Error("some message");
+            err.name = "TargetCloseError";
+
+            assert.isTrue(shouldIgnoreUnhandledRejection(err));
+        });
+
+        it("should ignore known Puppeteer error messages originating from puppeteer-core", () => {
+            const err = new Error("Cannot extract value when objectId is given");
+            err.stack = "Error: ...\n    at .../node_modules/puppeteer-core/lib/foo.js:1:1";
+
+            assert.isTrue(shouldIgnoreUnhandledRejection(err));
+        });
+
+        it("should not ignore a Puppeteer-shaped message that did not come from puppeteer-core", () => {
+            const err = new Error("Cannot extract value when objectId is given");
+            err.stack = "Error: ...\n    at /my-project/src/index.js:1:1";
+
+            assert.isFalse(shouldIgnoreUnhandledRejection(err));
+        });
+
+        it("should not ignore an arbitrary error by default", () => {
+            assert.isFalse(shouldIgnoreUnhandledRejection(new Error("something genuinely broke")));
+        });
+
+        describe("registerUnhandledRejectionFilter", () => {
+            const registeredUnregisterFns: Array<() => void> = [];
+
+            afterEach(() => {
+                registeredUnregisterFns.splice(0).forEach(unregister => unregister());
+            });
+
+            const register = (filter: (err: Error) => boolean): void => {
+                registeredUnregisterFns.push(registerUnhandledRejectionFilter(filter));
+            };
+
+            it("should ignore a rejection a registered filter matches", () => {
+                register(err => err.message === "known-safe failure");
+
+                assert.isTrue(shouldIgnoreUnhandledRejection(new Error("known-safe failure")));
+            });
+
+            it("should not ignore a rejection no registered filter matches", () => {
+                register(err => err.message === "known-safe failure");
+
+                assert.isFalse(shouldIgnoreUnhandledRejection(new Error("something else")));
+            });
+
+            it("should consult every registered filter, not just the first one", () => {
+                register(() => false);
+                register(err => err.message === "matched-by-second-filter");
+
+                assert.isTrue(shouldIgnoreUnhandledRejection(new Error("matched-by-second-filter")));
+            });
+
+            it("should treat a throwing filter as not matched, and not let it break other filters", () => {
+                register(() => {
+                    throw new Error("filter itself is broken");
+                });
+                register(err => err.message === "still works");
+
+                assert.isFalse(shouldIgnoreUnhandledRejection(new Error("unrelated")));
+                assert.isTrue(shouldIgnoreUnhandledRejection(new Error("still works")));
+            });
+
+            it("should stop consulting a filter once it has been unregistered", () => {
+                const unregister = registerUnhandledRejectionFilter(err => err.message === "temporary");
+
+                assert.isTrue(shouldIgnoreUnhandledRejection(new Error("temporary")));
+
+                unregister();
+
+                assert.isFalse(shouldIgnoreUnhandledRejection(new Error("temporary")));
+            });
+
+            it("should never override the built-in Puppeteer allowlist behavior", () => {
+                register(() => false);
+
+                const err = new Error("some message");
+                err.name = "ProtocolError";
+
+                assert.isTrue(shouldIgnoreUnhandledRejection(err));
+            });
+        });
+    });
+});


### PR DESCRIPTION
### What's done?

Context:
- Any unhandled rejection in a worker terminates the whole run (#744) — a safety net for tests missing an `await`
- `shouldIgnoreUnhandledRejection` already carves out an exception for known Puppeteer/CDP noise, but it's a hardcoded, closed list
- Ran into a case where a plugin (not an actual test) triggers an unrelated async rejection while just reading a file for its own config, before any test even starts — same blanket policy kills the whole run for that too, with no way to tell Testplane "this one's fine"

This adds `registerUnhandledRejectionFilter(filter)` (exposed via `testplane/unstable`) so a plugin or integration can register its own predicate for cases like that, instead of it needing to get hardcoded into core the way Puppeteer's was:

```ts
import { registerUnhandledRejectionFilter } from "testplane/unstable";

const unregister = registerUnhandledRejectionFilter(err => isKnownSafeToIgnore(err));
```

A filter can only ever make something get ignored, never the reverse, and a filter that throws is just treated as "no match" and logged, so a broken filter can't hide a real error. The built-in Puppeteer allowlist still takes priority. Default behavior is unchanged for everyone who doesn't use this.

### How I tested?

Unit tests covering filter registration/unregistration, multiple filters, a throwing filter not breaking anything else, and the built-in Puppeteer allowlist still taking priority. Full existing suite is still green.
