### PR TITLE
fix: handle disappearing iframes during screenshot preparation

### DIFF
--- a/src/browser/screen-shooter/operations/iframe.ts
+++ b/src/browser/screen-shooter/operations/iframe.ts
@@ -1,31 +1,40 @@
 import type { ElementReference } from "@testplane/wdio-protocols";
+import { loadEsm } from "../../../utils/preload-utils";
+import { warn } from "../../../utils/logger";
+
+type VisibilityScript = (element: ElementReference) => boolean;
 
 export async function runInEachDisplayedIframe(
     session: WebdriverIO.Browser,
     cb: () => Promise<unknown> | unknown,
 ): Promise<void> {
-    const iframes = await session.findElements("css selector", "iframe[src]");
-    const displayedIframes: ElementReference[] = [];
-
-    await Promise.all(
-        iframes.map(async iframe => {
-            const isIframeDisplayed = await session.$(iframe).isDisplayed();
-
-            if (isIframeDisplayed) {
-                displayedIframes.push(iframe);
-            }
-        }),
+    const { default: isElementDisplayed } = await loadEsm<{ default: VisibilityScript }>(
+        "@testplane/webdriverio/scripts/isElementDisplayed.js",
     );
+    const iframes = await session.findElements("css selector", "iframe[src]");
 
-    try {
-        for (const iframe of displayedIframes) {
+    for (const iframe of iframes) {
+        try {
+            // Raw element references have no selector for WDIO to refetch if the iframe disappears.
+            if (!(await session.execute(isElementDisplayed, iframe))) {
+                continue;
+            }
             await session.switchToFrame(iframe);
+        } catch (error) {
+            const errorCode = (error as { error?: string; name?: string }).error ?? (error as Error).name;
+            if (errorCode !== "stale element reference" && errorCode !== "no such frame") {
+                throw error;
+            }
+            warn("Skipping an iframe that disappeared before screenshot preparation", { iframe, errorCode });
+            await session.switchToFrame(null);
+            continue;
+        }
+
+        try {
             await cb();
+        } finally {
             // switchToParentFrame does not work in ios - https://github.com/appium/appium/issues/14882
             await session.switchToFrame(null);
         }
-    } catch (e) {
-        await session.switchToFrame(null);
-        throw e;
     }
 }

--- a/test/src/browser/screen-shooter/operations/iframe.js
+++ b/test/src/browser/screen-shooter/operations/iframe.js
@@ -1,0 +1,106 @@
+"use strict";
+
+const proxyquire = require("proxyquire").noCallThru();
+
+describe("runInEachDisplayedIframe", () => {
+    const sandbox = sinon.createSandbox();
+    const first = { "element-6066-11e4-a52e-4f735466cecf": "first" };
+    const second = { "element-6066-11e4-a52e-4f735466cecf": "second" };
+    let session;
+    let callback;
+    let runInEachDisplayedIframe;
+    let visibilityScript;
+    let loadEsm;
+    let warn;
+
+    beforeEach(() => {
+        visibilityScript = () => true;
+        loadEsm = sandbox.stub().resolves({ default: visibilityScript });
+        warn = sandbox.stub();
+        ({ runInEachDisplayedIframe } = proxyquire("src/browser/screen-shooter/operations/iframe", {
+            "../../../utils/preload-utils": { loadEsm },
+            "../../../utils/logger": { warn },
+        }));
+        session = {
+            findElements: sandbox.stub().resolves([first, second]),
+            execute: sandbox.stub().resolves(true),
+            switchToFrame: sandbox.stub().resolves(),
+        };
+        callback = sandbox.stub().resolves();
+    });
+
+    afterEach(() => sandbox.restore());
+
+    it("should check visibility without creating a selectorless WDIO element", async () => {
+        await runInEachDisplayedIframe(session, callback);
+
+        assert.calledOnceWithExactly(loadEsm, "@testplane/webdriverio/scripts/isElementDisplayed.js");
+        assert.calledOnceWithExactly(session.findElements, "css selector", "iframe[src]");
+        assert.calledWithExactly(session.execute, visibilityScript, first);
+        assert.calledWithExactly(session.execute, visibilityScript, second);
+        assert.deepEqual(session.switchToFrame.args, [[first], [null], [second], [null]]);
+        assert.calledTwice(callback);
+        assert.callOrder(session.execute, session.switchToFrame, callback);
+    });
+
+    it("should skip hidden iframes", async () => {
+        session.execute.onFirstCall().resolves(false);
+
+        await runInEachDisplayedIframe(session, callback);
+
+        assert.deepEqual(session.switchToFrame.args, [[second], [null]]);
+        assert.calledOnce(callback);
+    });
+
+    it("should handle an empty iframe list", async () => {
+        session.findElements.resolves([]);
+
+        await runInEachDisplayedIframe(session, callback);
+
+        assert.notCalled(session.execute);
+        assert.notCalled(session.switchToFrame);
+        assert.notCalled(callback);
+    });
+
+    for (const command of ["execute", "switchToFrame"]) {
+        for (const errorCode of ["stale element reference", "no such frame"]) {
+            for (const field of ["name", "error"]) {
+                it(`should skip an iframe when ${command} fails with ${errorCode} in ${field}`, async () => {
+                    session[command]
+                        .onFirstCall()
+                        .rejects(Object.assign(new Error("disappeared"), { [field]: errorCode }));
+
+                    await runInEachDisplayedIframe(session, callback);
+
+                    assert.calledOnce(callback);
+                    assert.calledWithExactly(session.switchToFrame, second);
+                    assert.deepEqual(session.switchToFrame.lastCall.args, [null]);
+                    assert.calledOnce(warn);
+                });
+            }
+        }
+
+        it(`should propagate unexpected ${command} errors`, async () => {
+            const error = new Error("connection lost");
+            session[command].onFirstCall().rejects(error);
+
+            assert.strictEqual(await assert.isRejected(runInEachDisplayedIframe(session, callback)), error);
+
+            assert.notCalled(callback);
+            assert.notCalled(warn);
+        });
+    }
+
+    for (const name of ["Error", "stale element reference", "no such frame"]) {
+        it(`should restore the top frame and propagate a callback ${name}`, async () => {
+            const error = Object.assign(new Error("callback failed"), { name });
+            callback.rejects(error);
+
+            assert.strictEqual(await assert.isRejected(runInEachDisplayedIframe(session, callback)), error);
+
+            assert.deepEqual(session.switchToFrame.args, [[first], [null]]);
+            assert.calledOnce(callback);
+            assert.notCalled(warn);
+        });
+    }
+});


### PR DESCRIPTION
# fix: handle disappearing iframes during screenshot preparation

## Summary

Handle auxiliary iframes that disappear while `assertView` prepares or cleans up page animations.

`runInEachDisplayedIframe` currently calls `session.$(iframe).isDisplayed()` with a raw WebDriver element reference. Such an element has no selector. If it becomes stale during the visibility check, WDIO attempts to refetch it using an undefined selector, masking the original error with `selector needs to be typeof string or function, but found: undefined`. An iframe can also disappear between the visibility check and `switchToFrame`.

- Execute WDIO's existing visibility script directly, preserving visibility semantics without selector-based refetch.
- Check and enter each iframe sequentially.
- Skip only `stale element reference` / `no such frame` errors during the visibility check or frame entry, with a warning and a reset to the top-level frame.
- Preserve callback errors, including stale-element errors, and restore the top-level frame in `finally`.
- Add 16 unit tests in the existing Mocha/Sinon suite. No dependency or lockfile changes.

## Validation

- `npm run build`: passed.
- `npm test`: 3472 passing, 1 pending; type checking and lint passed.
- Focused regression suite: 16 passing. With the original implementation restored: 15 failing, 1 passing.
- Real desktop Chrome: 12 regression checks passed, including deterministic iframe removal after discovery and before frame entry, hidden iframes, and callback error propagation.
- Real Android Chrome 101: the same 12 regression checks passed.
- Built upstream Testplane, without module replacement: all 6 real `assertView` cases passed against existing screenshot references, with `disableAnimation: true`, `retry: 0`, and no reference updates.

The real-browser checks used an external temporary reproducer; they are not part of this PR's committed test suite. Full upstream e2e/browser-env suites and the original Storybook CI job were not run.

## CLA

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru.
